### PR TITLE
Refactor: Update Google AI library dependencies and imports

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -2,7 +2,7 @@
 import json
 import os
 import traceback
-from google.generativeai import types # SAFETY_CONFIG定義のため
+from google.genai import types # SAFETY_CONFIG定義のため
 
 # --- 設定関連定数 ---
 CONFIG_FILE = "config.json"

--- a/gemini_api.py
+++ b/gemini_api.py
@@ -2,7 +2,6 @@
 import google.genai as genai
 from google.genai import types
 from google.genai.types import Tool, GoogleSearch, GenerateContentConfig, Content, Part, GenerateImagesConfig # Added GenerateImagesConfig
-from google.ai.generativelanguage import HarmCategory, SafetySetting
 import os
 import json
 import google.api_core.exceptions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+google-genai


### PR DESCRIPTION
I switched your project to exclusively use the `google-genai` library for interactions with Google's generative AI models.

Key changes include:
- Modified `config_manager.py` to import `types` from `google.genai` instead of `google.generativeai`.
- Updated `gemini_api.py` to remove direct imports from `google.ai.generativelanguage`, relying on `google.genai` for necessary types like `HarmCategory`.
- Created a `requirements.txt` file specifying `google-genai` as the sole Google AI dependency, effectively removing `google-generativeai` and `google-cloud-aiplatform` from the project's declared dependencies.
- Verified that other Python files in your project do not have direct imports of the older Google AI libraries.

These changes ensure your project uses the latest recommended Google AI library and consolidates its AI-related dependencies.