### PR TITLE
fix: Synchronize log editor reload and apply height styling

### DIFF
--- a/log2gemini.py
+++ b/log2gemini.py
@@ -51,8 +51,9 @@ custom_css = """
     display: block !important; /* Explicitly make it a block to fill width */
     width: 100% !important;    /* Ensure it uses the container's width */
 }
-#memory_json_editor_code .cm-editor { max-height: 300px !important; overflow-y: auto !important; }
-#memory_json_editor_code { max-height: 310px; overflow: hidden; border: 1px solid #ccc; border-radius: 5px; }
+/* 修正点：#log_editor_code を追加 */
+#memory_json_editor_code .cm-editor, #log_editor_code .cm-editor { max-height: 300px !important; overflow-y: auto !important; }
+#memory_json_editor_code, #log_editor_code { max-height: 310px; overflow: hidden; border: 1px solid #ccc; border-radius: 5px; }
 #alarm_checklist .gr-input-label { margin-bottom: 5px !important; }
 #alarm_checklist .gr-check-radio > label { padding: 4px 0 !important; display: block; }
 #help_accordion code { background-color: #eee; padding: 2px 4px; border-radius: 3px; font-size: 0.9em; }
@@ -394,7 +395,7 @@ with gr.Blocks(theme=gr.themes.Soft(primary_hue="blue", secondary_hue="sky"), cs
         reload_button.click(
             fn=ui_handlers.reload_chat_log,
             inputs=[current_character_name],
-            outputs=[chatbot]
+            outputs=[chatbot, log_editor] # 修正点：log_editorを追加
         )
 
 # --- アプリケーション起動 ---


### PR DESCRIPTION
This commit addresses issues with the chat log editing feature:
1. The log editor area (`log_editor`) did not refresh its content when you clicked the main reload button.
2. The log editor area did not have a maximum height restriction, unlike the memory editor, causing potential layout issues.

Changes:

- **`ui_handlers.py`:**
    - I modified `reload_chat_log` to return a tuple containing both the formatted chat history for the `chatbot` and the raw string content of the `log.txt` file for the `log_editor`.

- **`log2gemini.py`:**
    - I updated the `reload_button.click()` event: the `outputs` list now includes `log_editor` in addition to `chatbot`. This ensures both components are refreshed with data from the updated `reload_chat_log` function.
    - I modified `custom_css`: The CSS rules for `max-height` and `overflow` previously applied to `#memory_json_editor_code` (and its `.cm-editor`) are now also applied to `#log_editor_code` (and its `.cm-editor`), ensuring consistent styling and behavior for both editors.

These changes improve your experience by ensuring the log editor's content is correctly synchronized upon reload and by maintaining a consistent UI layout.