### PR TITLE
Fix: Implement chat history limiting in send_to_gemini

### DIFF
--- a/gemini_api.py
+++ b/gemini_api.py
@@ -83,6 +83,21 @@ def send_to_gemini(system_prompt_path, log_file_path, user_prompt, selected_mode
 
     # Ensure load_chat_log is available (from utils)
     msgs = load_chat_log(log_file_path, character_name)
+
+    if api_history_limit_option.isdigit():
+        try:
+            limit = int(api_history_limit_option)
+            if limit > 0:
+                # 1往復 = 2メッセージ (user, model)
+                limit_msgs = limit * 2
+                if len(msgs) > limit_msgs:
+                    print(f"情報: 履歴を直近 {limit} 往復 ({limit_msgs} メッセージ) に制限します。")
+                    msgs = msgs[-limit_msgs:]
+        except ValueError:
+            # isdigit()でチェックしているので基本的にはここに来ないはず
+            print(f"警告: api_history_limit_option '{api_history_limit_option}' は不正な数値です。履歴は制限されません。")
+    # "all" の場合は何もしない (全履歴を使用)
+
     if msgs and msgs[-1].get("role") == "user":
         print("情報: ログ末尾のユーザーメッセージを履歴から一時的に削除し、引数の内容で上書きします。")
         msgs = msgs[:-1]


### PR DESCRIPTION
The send_to_gemini function in gemini_api.py was not limiting the number of chat logs sent to the API, regardless of the api_history_limit_option setting. This could lead to unintended token consumption.

This commit introduces the logic to correctly limit the chat history based on the api_history_limit_option.
- If a numeric value (e.g., "10") is provided, the history will be truncated to the specified number of conversation turns (e.g., 10 turns = 20 messages).
- If "all" is specified, the entire chat history will be sent.
- Appropriate logging has been added to indicate when the history is being limited.

This fix ensures that the API history limit functions as intended, matching the behavior already present in the send_alarm_to_gemini function.