### PR TITLE
Add .xml to allowed file types for Gradio app

### DIFF
--- a/log2gemini.py
+++ b/log2gemini.py
@@ -116,7 +116,7 @@ with gr.Blocks(theme=gr.themes.Soft(primary_hue="blue", secondary_hue="sky"), cs
             with gr.Row():
                 submit_button = gr.Button("送信", variant="primary", scale=4)
                 chat_reload_button = gr.Button("🔄 更新", scale=1)
-            allowed_file_types = ['.png', '.jpg', '.jpeg', '.webp', '.heic', '.heif', '.mp3', '.wav', '.flac', '.aac', '.mp4', '.mov', '.avi', '.webm', '.txt', '.md', '.py', '.js', '.html', '.css', '.pdf']
+            allowed_file_types = ['.png', '.jpg', '.jpeg', '.webp', '.heic', '.heif', '.mp3', '.wav', '.flac', '.aac', '.mp4', '.mov', '.avi', '.webm', '.txt', '.md', '.py', '.js', '.html', '.css', '.pdf', '.xml']
             file_upload_button = gr.Files(label="ファイル添付", type="filepath", file_count="multiple", file_types=allowed_file_types)
             gr.Markdown(f"ℹ️ *複数のファイルを添付できます。対応形式: {', '.join(allowed_file_types)}*")
 


### PR DESCRIPTION
This change allows users to upload XML files by adding '.xml' to the `allowed_file_types` list in `log2gemini.py`.

The Gradio Markdown display for allowed file types will automatically update as it directly references this list.