### PR TITLE
Fix: 履歴取得ロジックを往復数ベースに修正

### DIFF
--- a/gemini_api.py
+++ b/gemini_api.py
@@ -61,8 +61,11 @@ def invoke_nexus_agent(character_name: str, model_name: str, parts: list, api_hi
             limit = int(api_history_limit_option)
 
         if limit > 0:
-            if len(messages) > limit: # limit は Human/AIメッセージのペア数ではなく、総メッセージ数
-                messages = messages[-limit:]
+            # limit は往復数なので、実際に取得するメッセージ数は limit * 2
+            # SystemMessageを除いたメッセージリストの長さを考慮する
+            actual_messages_count = len(messages)
+            if actual_messages_count > limit * 2:
+                messages = messages[-(limit * 2):]
 
         # SystemMessageをリストの先頭に戻す
         if history_messages: # history_messages には SystemMessage が一つだけ入っている想定


### PR DESCRIPTION
`gemini_api.py`の`invoke_nexus_agent`関数において、
APIに送信する会話履歴の件数が設定値（往復数）の
2倍になるよう修正しました。

これにより、`config.json`の`conversation_history_count`が
メッセージ総数ではなく往復数として正しく解釈されるようになります。