### PR TITLE
fix: handle_chatbot_selectionのTypeErrorを修正

### DIFF
--- a/ui_handlers.py
+++ b/ui_handlers.py
@@ -286,6 +286,11 @@ def handle_chatbot_selection(character_name: str, api_history_limit_state: str, 
     try:
         clicked_ui_index = evt.index
 
+        # ★★★ この一行を追加 ★★★
+        # もしリストで来た場合は、最初の要素だけを使う
+        if isinstance(clicked_ui_index, list):
+            clicked_ui_index = clicked_ui_index[0]
+
         log_f, _, _, _, _ = get_character_files_paths(character_name)
         raw_history = utils.load_chat_log(log_f, character_name)
         display_turns = _get_display_history_count(api_history_limit_state)


### PR DESCRIPTION
GradioのSelectDataイベントにおいて、evt.indexがリスト形式で返される場合があるため、TypeErrorが発生していました。 この修正では、evt.indexがリストであるかを確認し、リストの場合は最初の要素を取得するように変更しました。 これにより、チャットメッセージ選択時の安定性が向上します。