### PR TITLE
Fix: Refactor chat history handling to prevent Gradio crash

### DIFF
--- a/nexus_ark.py
+++ b/nexus_ark.py
@@ -85,10 +85,9 @@ try:
         selected_message_state = gr.State(None)
         audio_player = gr.Audio(visible=False, autoplay=True)
 
-        # ★★★ ここからがUIレイアウトの再定義 ★★★
+        # (UIレイアウト定義は変更なし)
         with gr.Row():
             with gr.Column(scale=1, min_width=300):
-                # (左カラムのUI定義は変更なし)
                 profile_image_display = gr.Image(height=150, width=150, interactive=False, show_label=False, container=False)
                 character_dropdown = gr.Dropdown(choices=character_list_on_startup, value=effective_initial_character, label="キャラクターを選択", interactive=True)
                 with gr.Accordion("空間認識・移動", open=True):
@@ -114,7 +113,6 @@ try:
                             gr.Markdown("---")
                             save_char_settings_button = gr.Button("このキャラクターの設定を保存", variant="primary")
                         with gr.TabItem("共通設定"):
-                            # (共通設定タブの中身は変更なし)
                             model_dropdown = gr.Dropdown(choices=config_manager.AVAILABLE_MODELS_GLOBAL, value=config_manager.initial_model_global, label="使用するAIモデル", interactive=True)
                             api_key_dropdown = gr.Dropdown(choices=list(config_manager.API_KEYS.keys()), value=config_manager.initial_api_key_name_global, label="使用するAPIキー", interactive=True)
                             api_history_limit_dropdown = gr.Dropdown(choices=list(config_manager.API_HISTORY_LIMIT_OPTIONS.values()), value=config_manager.API_HISTORY_LIMIT_OPTIONS.get(config_manager.initial_api_history_limit_option_global, "全ログ"), label="APIへの履歴送信", interactive=True)
@@ -174,7 +172,6 @@ try:
                         add_character_button = gr.Button("迎える", variant="secondary", scale=1)
 
             with gr.Column(scale=3):
-                # (右カラムのUI定義は変更なし)
                 chatbot_display = gr.Chatbot(height=600, elem_id="chat_output_area", show_copy_button=True, show_label=False)
                 with gr.Row(visible=False) as action_button_group:
                     play_audio_button = gr.Button("🔊 選択した発言を再生")
@@ -190,7 +187,7 @@ try:
                 file_upload_button = gr.Files(label="ファイル添付", type="filepath", file_count="multiple", file_types=allowed_file_types)
                 gr.Markdown(f"ℹ️ *複数のファイルを添付できます。対応形式: {', '.join(allowed_file_types)}*")
 
-        # ★★★ ここからがイベントハンドラ定義の再構築 ★★★
+        # --- ★★★ ここからがイベントハンドラ定義の再構築 ★★★ ---
 
         # --- 司令塔となる入力・出力リスト ---
         char_change_outputs = [
@@ -258,8 +255,16 @@ try:
         api_history_limit_dropdown.change(fn=ui_handlers.update_api_history_limit_state_and_reload_chat, inputs=[api_history_limit_dropdown, current_character_name], outputs=[api_history_limit_state, chatbot_display, gr.State()]).then(fn=ui_handlers.update_token_count_from_state, inputs=[current_character_name, current_api_key_name_state], outputs=token_count_display)
 
         # --- チャット関連イベント ---
-        chat_inputs = [chat_input_textbox, chatbot_display, current_character_name, current_api_key_name_state, file_upload_button, add_timestamp_checkbox, api_history_limit_state]
-        chat_submit_outputs = [chatbot_display, chat_input_textbox, file_upload_button, token_count_display, current_location_display, current_scenery_display, alarm_dataframe_original_data, alarm_dataframe]
+        # ★★★ 変更点: chat_inputsからchatbot_displayを削除 ★★★
+        chat_inputs = [
+            chat_input_textbox, current_character_name, current_api_key_name_state,
+            file_upload_button, add_timestamp_checkbox, api_history_limit_state
+        ]
+        chat_submit_outputs = [
+            chatbot_display, chat_input_textbox, file_upload_button,
+            token_count_display, current_location_display, current_scenery_display,
+            alarm_dataframe_original_data, alarm_dataframe
+        ]
 
         chat_input_textbox.submit(fn=ui_handlers.handle_message_submission, inputs=chat_inputs, outputs=chat_submit_outputs)
         submit_button.click(fn=ui_handlers.handle_message_submission, inputs=chat_inputs, outputs=chat_submit_outputs)
@@ -272,7 +277,7 @@ try:
         file_upload_button.upload(fn=ui_handlers.update_token_count_on_input, inputs=token_calc_on_input_inputs, outputs=token_count_display, show_progress=False)
         file_upload_button.clear(fn=ui_handlers.update_token_count_on_input, inputs=token_calc_on_input_inputs, outputs=token_count_display, show_progress=False)
 
-        # --- その他のイベント ---
+        # --- その他のイベント (変更なし) ---
         add_character_button.click(fn=ui_handlers.handle_add_new_character, inputs=[new_character_name_textbox], outputs=[character_dropdown, alarm_char_dropdown, timer_char_dropdown, new_character_name_textbox])
         change_location_button.click(fn=ui_handlers.handle_location_change, inputs=[current_character_name, location_dropdown], outputs=[current_location_display, current_scenery_display])
         refresh_scenery_button.click(fn=ui_handlers.handle_scenery_refresh, inputs=[current_character_name, api_key_dropdown], outputs=[current_location_display, current_scenery_display])
@@ -282,7 +287,6 @@ try:
         delete_selection_button.click(fn=ui_handlers.handle_delete_button_click, inputs=[selected_message_state, current_character_name, api_history_limit_state], outputs=[chatbot_display, selected_message_state, action_button_group])
         cancel_selection_button.click(fn=lambda: (None, gr.update(visible=False)), inputs=None, outputs=[selected_message_state, action_button_group])
 
-        # (記憶、メモ、アラーム、タイマー関連のイベントは変更なし)
         save_memory_button.click(fn=ui_handlers.handle_save_memory_click, inputs=[current_character_name, memory_json_editor], outputs=[memory_json_editor]).then(fn=lambda: gr.update(variant="secondary"), inputs=None, outputs=[save_memory_button])
         reload_memory_button.click(fn=ui_handlers.handle_reload_memory, inputs=[current_character_name], outputs=[memory_json_editor])
         save_notepad_button.click(fn=ui_handlers.handle_save_notepad_click, inputs=[current_character_name, notepad_editor], outputs=[notepad_editor])
@@ -312,6 +316,7 @@ try:
         print("  (IPアドレスが分からない場合は、PCのコマンドプロンプトやターミナルで")
         print("   `ipconfig` (Windows) または `ifconfig` (Mac/Linux) と入力して確認できます)")
         print("="*60 + "\n")
+        # 起動時の allowed_paths にカレントディレクトリを追加
         demo.queue().launch(server_name="0.0.0.0", server_port=7860, share=False, allowed_paths=["."])
 
 except Exception as e:

--- a/ui_handlers.py
+++ b/ui_handlers.py
@@ -1,7 +1,6 @@
 # ui_handlers.py の内容を、このコードで完全に置き換えてください
 
 import pandas as pd
-# ... (他のimportは変更なし)
 import json
 import traceback
 import os
@@ -14,6 +13,7 @@ import threading
 import filetype
 import base64
 import io
+import uuid # ユーザー入力のHTMLフォーマット用にインポート
 
 import gemini_api, config_manager, alarm_manager, character_manager, utils
 from tools import memory_tools
@@ -24,20 +24,13 @@ from memory_manager import load_memory_data_safe, save_memory_data
 DAY_MAP_EN_TO_JA = {"mon": "月", "tue": "火", "wed": "水", "thu": "木", "fri": "金", "sat": "土", "sun": "日"}
 DAY_MAP_JA_TO_EN = {v: k for k, v in DAY_MAP_EN_TO_JA.items()}
 
-# ... (グローバル定数や、変更のない関数は省略) ...
-
 def handle_initial_load():
     """アプリ起動時に一度だけ呼ばれるハンドラ"""
     print("--- UI初期化処理(handle_initial_load)を開始します ---")
-
-    # 1. キャラクター非依存のUIを初期化
     df_with_ids = render_alarms_as_dataframe()
     display_df = get_display_df(df_with_ids)
     feedback_text = "アラームを選択してください"
-
-    # 2. handle_character_changeを呼び出して、キャラクター依存のUIを初期化
     char_dependent_outputs = handle_character_change(config_manager.initial_character_global)
-
     return (display_df, df_with_ids, feedback_text) + char_dependent_outputs
 
 def handle_character_change(character_name: str):
@@ -48,14 +41,12 @@ def handle_character_change(character_name: str):
     print(f"--- UI更新司令塔(handle_character_change)実行: {character_name} ---")
     config_manager.save_config("last_character", character_name)
 
-    # --- 各種ファイルパスとデータの読み込み ---
     log_f, _, img_p, mem_p, notepad_p = get_character_files_paths(character_name)
     chat_history, _ = utils.format_history_for_gradio(utils.load_chat_log(log_f, character_name)[-(config_manager.UI_HISTORY_MAX_LIMIT * 2):], character_name)
     memory_str = json.dumps(load_memory_data_safe(mem_p), indent=2, ensure_ascii=False)
     profile_image = img_p if img_p and os.path.exists(img_p) else None
     notepad_content = load_notepad_content(character_name)
 
-    # --- 空間認識UIの更新 ---
     locations = get_location_list_for_ui(character_name)
     current_location_id = utils.get_current_location(character_name)
     memory_data = load_memory_data_safe(mem_p)
@@ -64,11 +55,10 @@ def handle_character_change(character_name: str):
     location_dd_val = current_location_id if current_location_id in valid_location_ids else None
     scenery_text = "（AIとの対話開始時に生成されます）"
 
-    # --- キャラクター個別設定UIの更新 ---
     effective_settings = config_manager.get_effective_settings(character_name)
     all_models = ["デフォルト"] + config_manager.AVAILABLE_MODELS_GLOBAL
     model_val = effective_settings["model_name"] if effective_settings["model_name"] != config_manager.initial_model_global else "デフォルト"
-    voice_display_name = config_manager.SUPPORTED_VOICES.get(effective_settings["voice_id"], list(config_manager.SUPPORTED_VOICES.values())[0])
+    voice_display_name = config_manager.SUPPORTED_VOICES.get(effective_settings.get("voice_id", "vindemiatrix"), list(config_manager.SUPPORTED_VOICES.values())[0])
 
     return (
         character_name, chat_history, "", profile_image, memory_str, character_name,
@@ -89,12 +79,11 @@ def handle_save_char_settings(
     send_thoughts: bool, send_notepad: bool, use_common_prompt: bool,
     send_core_memory: bool, send_scenery: bool
 ):
-    """【改修版】キャラクター個別設定を安全に保存する司令塔ハンドラ"""
+    """キャラクター個別設定を安全に保存する司令塔ハンドラ"""
     if not character_name:
         gr.Warning("設定を保存するキャラクターが選択されていません。")
         return
 
-    # ★★★ ここからがJSON破損を防ぐ修正 ★★★
     new_settings = {
         "model_name": model_name if model_name != "デフォルト" else None,
         "voice_id": next((k for k, v in config_manager.SUPPORTED_VOICES.items() if v == voice_name), None),
@@ -112,13 +101,10 @@ def handle_save_char_settings(
             with open(char_config_path, "r", encoding="utf-8") as f:
                 config = json.load(f)
 
-        if "override_settings" not in config:
-            config["override_settings"] = {}
+        if "override_settings" not in config: config["override_settings"] = {}
 
-        # 既存の設定を保持しつつ、新しい設定で更新する
         config["override_settings"].update(new_settings)
         config["last_updated"] = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-        # ★★★ 修正箇所ここまで ★★★
 
         with open(char_config_path, "w", encoding="utf-8") as f:
             json.dump(config, f, indent=2, ensure_ascii=False)
@@ -132,57 +118,41 @@ def handle_save_char_settings(
 def update_token_count_from_state(character_name: str, api_key_name: str):
     """設定変更時に呼ばれる。テキスト入力は考慮せず、履歴とプロンプトのみで計算"""
     if not character_name or not api_key_name: return "入力トークン数: -"
-    token_count_str = gemini_api.count_input_tokens(
-        character_name=character_name,
-        api_key_name=api_key_name,
-        parts=[] # テキスト入力は空として計算
-    )
-    return token_count_str
+    # 'parts' はキーワード引数として渡す必要がある
+    return gemini_api.count_input_tokens(character_name=character_name, api_key_name=api_key_name, parts=[])
 
 def update_token_count_on_input(character_name: str, api_key_name: str, textbox_content: str, file_list: list):
     """テキスト入力やファイル添付時に呼ばれる。現在の入力内容を含めて計算"""
     if not character_name or not api_key_name: return "入力トークン数: -"
-
     parts_for_api = []
-    if textbox_content:
-        parts_for_api.append(textbox_content)
+    if textbox_content: parts_for_api.append(textbox_content)
     if file_list:
         for file_obj in file_list:
-            filepath = file_obj.name
-            try:
-                kind = filetype.guess(filepath)
-                if kind and kind.mime.startswith("image/"):
-                    parts_for_api.append(Image.open(filepath))
-                else:
-                    with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
-                        parts_for_api.append(f.read())
-            except Exception as e:
-                print(f"Token count on input error (file handling): {e}")
-                # Fallback for non-text files that can't be opened
-                parts_for_api.append(f"[ファイル: {os.path.basename(filepath)}]")
+            parts_for_api.append(Image.open(file_obj.name))
+    return gemini_api.count_input_tokens(character_name=character_name, api_key_name=api_key_name, parts=parts_for_api)
 
-
-    token_count_str = gemini_api.count_input_tokens(
-        character_name=character_name,
-        api_key_name=api_key_name,
-        parts=parts_for_api
-    )
-    return token_count_str
-
+# ★★★ ここからが修正のメインです ★★★
 def handle_message_submission(*args: Any):
-    (textbox_content, chatbot_history, current_character_name, current_api_key_name_state, file_input_list, add_timestamp_checkbox, api_history_limit_state) = args
+    (textbox_content, current_character_name, current_api_key_name_state,
+     file_input_list, add_timestamp_checkbox, api_history_limit_state) = args
 
     user_prompt_from_textbox = textbox_content.strip() if textbox_content else ""
+    # 1. ユーザー入力がない場合は何もしない
     if not user_prompt_from_textbox and not file_input_list:
+        chatbot_history = reload_chat_log(current_character_name, api_history_limit_state)
         token_count = update_token_count_from_state(current_character_name, current_api_key_name_state)
         yield chatbot_history, gr.update(), gr.update(), token_count, gr.update(), gr.update(), gr.update(), gr.update()
         return
 
+    # 2. UIに表示する現在の履歴をログから読み込む
+    chatbot_history = reload_chat_log(current_character_name, api_history_limit_state)
+
+    # 3. ユーザーの新しい入力をUI表示用履歴に追加
     log_message_parts = []
     if user_prompt_from_textbox:
         timestamp = f"\n\n{datetime.datetime.now().strftime('%Y-%m-%d (%a) %H:%M:%S')}" if add_timestamp_checkbox else ""
         processed_user_message = user_prompt_from_textbox + timestamp
-        chatbot_history.append((processed_user_message, None))
+        chatbot_history.append((processed_user_message, None)) # UIには単純な文字列タプルとして追加
         log_message_parts.append(processed_user_message)
 
     if file_input_list:
@@ -192,37 +162,30 @@ def handle_message_submission(*args: Any):
             chatbot_history.append(((filepath, filename), None))
             log_message_parts.append(f"[ファイル添付: {filepath}]")
 
+    # 4. 「思考中...」メッセージを追加してUIを更新
     chatbot_history.append((None, "思考中... ▌"))
-
     token_count = update_token_count_on_input(current_character_name, current_api_key_name_state, textbox_content, file_input_list)
-
     yield (
-        chatbot_history,
-        gr.update(value=""),
-        gr.update(value=None),
-        token_count,
-        gr.update(),
-        gr.update(),
-        gr.update(),
-        gr.update()
+        chatbot_history, gr.update(value=""), gr.update(value=None),
+        token_count, gr.update(), gr.update(), gr.update(), gr.update()
     )
 
+    # 5. エージェントを呼び出す (履歴は引数で渡さない)
     response_data = {}
     try:
         agent_args = (
-            textbox_content, chatbot_history, current_character_name,
-            current_api_key_name_state, file_input_list, add_timestamp_checkbox,
-            api_history_limit_state
+            textbox_content, current_character_name, current_api_key_name_state,
+            file_input_list, add_timestamp_checkbox, api_history_limit_state
         )
         response_data = gemini_api.invoke_nexus_agent(*agent_args)
     except Exception as e:
         traceback.print_exc()
         response_data = {"response": f"[UIハンドラエラー: {e}]", "location_name": "（エラー）", "scenery": "（エラー）"}
 
+    # 6. 応答をログに保存
     final_response_text = response_data.get("response", "")
     location_name = response_data.get("location_name", "（取得失敗）")
     scenery_text = response_data.get("scenery", "（取得失敗）")
-
     log_f, _, _, _, _ = get_character_files_paths(current_character_name)
     final_log_message = "\n\n".join(log_message_parts).strip()
     if final_log_message:
@@ -231,41 +194,30 @@ def handle_message_submission(*args: Any):
     if final_response_text:
         utils.save_message_to_log(log_f, f"## {current_character_name}:", final_response_text)
 
-    raw_history = utils.load_chat_log(log_f, current_character_name)
-    formatted_history, _ = utils.format_history_for_gradio(raw_history, current_character_name)
-
+    # 7. 最終的な全履歴を再フォーマットしてUIに反映
+    formatted_history = reload_chat_log(current_character_name, api_history_limit_state)
     token_count = update_token_count_from_state(current_character_name, current_api_key_name_state)
-
     new_alarm_df_with_ids = render_alarms_as_dataframe()
     new_display_df = get_display_df(new_alarm_df_with_ids)
-
     yield (
-        formatted_history,
-        gr.update(),
-        gr.update(value=None),
-        token_count,
-        location_name,
-        scenery_text,
-        new_alarm_df_with_ids,
-        new_display_df
+        formatted_history, gr.update(), gr.update(value=None),
+        token_count, location_name, scenery_text,
+        new_alarm_df_with_ids, new_display_df
     )
-# ... (the rest of the handler functions are assumed to be here, unchanged) ...
+# ★★★ ここまでが修正のメインです ★★★
+
 def _generate_initial_scenery(character_name: str, api_key_name: str) -> Tuple[str, str]:
     print("--- [軽量版] 情景生成を開始します ---")
     api_key = config_manager.API_KEYS.get(api_key_name)
     if not character_name or not api_key:
         return "（エラー）", "（キャラクターまたはAPIキーが未設定です）"
-
     from agent.graph import get_configured_llm
     from tools.memory_tools import read_memory_by_path
-
     location_id = utils.get_current_location(character_name) or "living_space"
     space_details_raw = read_memory_by_path.invoke({"path": f"living_space.{location_id}", "character_name": character_name})
-
     location_display_name = location_id
     space_def = "（現在の場所の定義・設定は、取得できませんでした）"
     scenery_text = "（場所の定義がないため、情景を描写できません）"
-
     try:
         if not space_details_raw.startswith("【エラー】"):
             try:
@@ -273,32 +225,19 @@ def _generate_initial_scenery(character_name: str, api_key_name: str) -> Tuple[s
                 if isinstance(space_data, dict):
                     location_display_name = space_data.get("name", location_id)
                     space_def = json.dumps(space_data, ensure_ascii=False, indent=2)
-                else:
-                    space_def = str(space_data)
-            except (json.JSONDecodeError, TypeError):
-                space_def = space_details_raw
-
+                else: space_def = str(space_data)
+            except (json.JSONDecodeError, TypeError): space_def = space_details_raw
             if not space_def.startswith("（"):
                 llm_flash = get_configured_llm("gemini-2.5-flash", api_key)
                 now = datetime.datetime.now()
-                scenery_prompt = (
-                    f"空間定義:{space_def}\n時刻:{now.strftime('%H:%M')} / 季節:{now.month}月\n\n"
-                    "以上の情報から、あなたはこの空間の「今この瞬間」を切り取る情景描写の専門家です。\n"
-                    "【ルール】\n"
-                    "- 人物やキャラクターの描写は絶対に含めないでください。\n"
-                    "- 1〜2文の簡潔な文章にまとめてください。\n"
-                    "- 窓の外の季節感や時間帯、室内の空気感や陰影など、五感に訴えかける精緻で写実的な描写を重視してください。"
-                )
+                scenery_prompt = (f"空間定義:{space_def}\n時刻:{now.strftime('%H:%M')} / 季節:{now.month}月\n\n以上の情報から、あなたはこの空間の「今この瞬間」を切り取る情景描写の専門家です。\n【ルール】\n- 人物やキャラクターの描写は絶対に含めないでください。\n- 1〜2文の簡潔な文章にまとめてください。\n- 窓の外の季節感や時間帯、室内の空気感や陰影など、五感に訴えかける精緻で写実的な描写を重視してください。")
                 scenery_text = llm_flash.invoke(scenery_prompt).content
                 print(f"  - 生成された情景: {scenery_text}")
-
     except Exception as e:
-        print(f"--- [軽量版] 情景生成中にエラー: {e}")
-        traceback.print_exc()
-        location_display_name = "（エラー）"
-        scenery_text = "（情景生成エラー）"
-
+        print(f"--- [軽量版] 情景生成中にエラー: {e}"); traceback.print_exc()
+        location_display_name, scenery_text = "（エラー）", "（情景生成エラー）"
     return location_display_name, scenery_text
+
 def handle_scenery_refresh(character_name: str, api_key_name: str) -> Tuple[str, str]:
     if not character_name or not api_key_name:
         return "（キャラクターまたはAPIキーが未選択です）", "（キャラクターまたはAPIキーが未選択です）"
@@ -306,9 +245,9 @@ def handle_scenery_refresh(character_name: str, api_key_name: str) -> Tuple[str,
     loc, scen = _generate_initial_scenery(character_name, api_key_name)
     gr.Info("情景を更新しました.")
     return loc, scen
+
 def handle_location_change(character_name: str, location_id: str) -> Tuple[str, str]:
     from tools.space_tools import set_current_location
-    print(f"--- UIからの場所変更処理開始: キャラクター='{character_name}', 移動先ID='{location_id}' ---")
     if not character_name or not location_id:
         gr.Warning("キャラクターと移動先の場所を選択してください。")
         current_loc_id = utils.get_current_location(character_name)
@@ -316,24 +255,20 @@ def handle_location_change(character_name: str, location_id: str) -> Tuple[str, 
     result = set_current_location.func(location=location_id, character_name=character_name)
     if "Success" not in result:
         gr.Error(f"場所の変更に失敗しました: {result}")
-        current_loc_id = utils.get_current_location(character_name)
-        return current_loc_id, f"（場所の変更に失敗: {result}）"
+        return utils.get_current_location(character_name), f"（場所の変更に失敗: {result}）"
     memory_data = load_memory_data_safe(get_character_files_paths(character_name)[3])
     new_location_name = memory_data.get("living_space", {}).get(location_id, {}).get("name", location_id)
     gr.Info(f"場所を「{new_location_name}」に変更しました。")
-    scenery_text = f"（場所を「{new_location_name}」に変更しました。情景は次の対話で生成されます）"
-    return new_location_name, scenery_text
+    return new_location_name, f"（場所を「{new_location_name}」に変更しました。情景は次の対話で生成されます）"
+
 def get_location_list_for_ui(character_name: str) -> list:
     if not character_name: return []
     _, _, _, memory_json_path, _ = get_character_files_paths(character_name)
     memory_data = load_memory_data_safe(memory_json_path)
     if "error" in memory_data or "living_space" not in memory_data: return []
     living_space = memory_data.get("living_space", {})
-    location_list = []
-    for loc_id, details in living_space.items():
-        if isinstance(details, dict):
-            location_list.append((details.get("name", loc_id), loc_id))
-    return sorted(location_list, key=lambda x: x[0])
+    return sorted([(details.get("name", loc_id), loc_id) for loc_id, details in living_space.items() if isinstance(details, dict)], key=lambda x: x[0])
+
 def handle_add_new_character(character_name: str):
     if not character_name or not character_name.strip():
         gr.Warning("キャラクター名が入力されていません。")
@@ -352,11 +287,12 @@ def handle_add_new_character(character_name: str):
         gr.Error(f"キャラクター「{safe_name}」の準備に失敗しました。")
         char_list = character_manager.get_character_list()
         return gr.update(choices=char_list), gr.update(choices=char_list), gr.update(choices=char_list), gr.update(value=character_name)
+
 def _get_display_history_count(api_history_limit_value: str) -> int:
     return int(api_history_limit_value) if api_history_limit_value.isdigit() else config_manager.UI_HISTORY_MAX_LIMIT
+
 def handle_chatbot_selection(character_name: str, api_history_limit_state: str, evt: gr.SelectData):
-    if not character_name or evt.index is None:
-        return None, gr.update(visible=False)
+    if not character_name or evt.index is None: return None, gr.update(visible=False)
     try:
         clicked_ui_index = evt.index[0]
         log_f, _, _, _, _ = get_character_files_paths(character_name)
@@ -365,35 +301,28 @@ def handle_chatbot_selection(character_name: str, api_history_limit_state: str, 
         visible_raw_history = raw_history[-(display_turns * 2):]
         _, mapping_list = utils.format_history_for_gradio(visible_raw_history, character_name)
         if not (0 <= clicked_ui_index < len(mapping_list)):
-            gr.Warning("Could not identify the clicked message (UI index out of bounds).")
+            gr.Warning("クリックされたメッセージを特定できませんでした (UI index out of bounds).")
             return None, gr.update(visible=False)
         original_log_index = mapping_list[clicked_ui_index]
         if 0 <= original_log_index < len(visible_raw_history):
-            selected_raw_message = visible_raw_history[original_log_index]
-            return selected_raw_message, gr.update(visible=True)
+            return visible_raw_history[original_log_index], gr.update(visible=True)
         else:
-            gr.Warning("Could not identify the clicked message (Original log index out of bounds).")
+            gr.Warning("クリックされたメッセージを特定できませんでした (Original log index out of bounds).")
             return None, gr.update(visible=False)
     except Exception as e:
-        print(f"Error during chatbot selection: {e}")
-        traceback.print_exc()
+        print(f"チャットボット選択中のエラー: {e}"); traceback.print_exc()
         return None, gr.update(visible=False)
+
 def handle_delete_button_click(message_to_delete: Optional[Dict[str, str]], character_name: str, api_history_limit: str):
     if not message_to_delete:
-        gr.Warning("No message selected for deletion.")
+        gr.Warning("削除対象のメッセージが選択されていません。")
         return gr.update(), None, gr.update(visible=False)
     log_f, _, _, _, _ = get_character_files_paths(character_name)
-    success = utils.delete_message_from_log(
-        log_file_path=log_f,
-        message_to_delete=message_to_delete,
-        character_name=character_name
-    )
-    if success:
-        gr.Info("Successfully deleted the message from the log.")
-    else:
-        gr.Error("Failed to delete the message. Check terminal for details.")
-    new_chat_history = reload_chat_log(character_name, api_history_limit)
-    return new_chat_history, None, gr.update(visible=False)
+    if utils.delete_message_from_log(log_f, message_to_delete, character_name):
+        gr.Info("ログからメッセージを削除しました。")
+    else: gr.Error("メッセージの削除に失敗しました。詳細はターミナルを確認してください。")
+    return reload_chat_log(character_name, api_history_limit), None, gr.update(visible=False)
+
 def reload_chat_log(character_name: Optional[str], api_history_limit_value: str):
     if not character_name: return []
     log_f,_,_,_,_ = get_character_files_paths(character_name)
@@ -401,278 +330,201 @@ def reload_chat_log(character_name: Optional[str], api_history_limit_value: str)
     display_turns = _get_display_history_count(api_history_limit_value)
     history, _ = utils.format_history_for_gradio(utils.load_chat_log(log_f, character_name)[-(display_turns*2):], character_name)
     return history
+
 def handle_save_memory_click(character_name, json_string_data):
     if not character_name:
-        gr.Warning("キャラクターが選択されていません。")
-        return gr.update()
-    try:
-        return save_memory_data(character_name, json_string_data)
+        gr.Warning("キャラクターが選択されていません。"); return gr.update()
+    try: return save_memory_data(character_name, json_string_data)
     except Exception as e:
-        gr.Error(f"記憶の保存中にエラーが発生しました: {e}")
-        return gr.update()
+        gr.Error(f"記憶の保存中にエラーが発生しました: {e}"); return gr.update()
+
 def handle_reload_memory(character_name: str) -> str:
     if not character_name:
-        gr.Warning("キャラクターが選択されていません。")
-        return "{}"
+        gr.Warning("キャラクターが選択されていません。"); return "{}"
     gr.Info(f"「{character_name}」の記憶を再読み込みしました。")
     _, _, _, memory_json_path, _ = get_character_files_paths(character_name)
-    memory_data = load_memory_data_safe(memory_json_path)
-    return json.dumps(memory_data, indent=2, ensure_ascii=False)
+    return json.dumps(load_memory_data_safe(memory_json_path), indent=2, ensure_ascii=False)
+
 def load_notepad_content(character_name: str) -> str:
     if not character_name: return ""
     _, _, _, _, notepad_path = get_character_files_paths(character_name)
     if notepad_path and os.path.exists(notepad_path):
-        with open(notepad_path, "r", encoding="utf-8") as f:
-            return f.read()
+        with open(notepad_path, "r", encoding="utf-8") as f: return f.read()
     return ""
+
 def handle_save_notepad_click(character_name: str, content: str) -> str:
     if not character_name:
-        gr.Warning("キャラクターが選択されていません。")
-        return content
+        gr.Warning("キャラクターが選択されていません。"); return content
     _, _, _, _, notepad_path = character_manager.get_character_files_paths(character_name)
     if not notepad_path:
-        gr.Error(f"「{character_name}」のメモ帳パス取得失敗。")
-        return content
-    lines = []
-    for line in content.strip().split('\n'):
-        line = line.strip()
-        if line and not re.match(r"^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}\]", line):
-            lines.append(f"[{datetime.datetime.now().strftime('%Y-%m-%d %H:%M')}] {line}")
-        elif line:
-            lines.append(line)
+        gr.Error(f"「{character_name}」のメモ帳パス取得失敗。"); return content
+    lines = [f"[{datetime.datetime.now().strftime('%Y-%m-%d %H:%M')}] {line.strip()}" if line.strip() and not re.match(r"^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}\]", line.strip()) else line.strip() for line in content.strip().split('\n') if line.strip()]
     final_content = "\n".join(lines)
     try:
-        with open(notepad_path, "w", encoding="utf-8") as f:
-            f.write(final_content + ('\n' if final_content else ''))
-        gr.Info(f"「{character_name}」のメモ帳を保存しました。")
-        return final_content
+        with open(notepad_path, "w", encoding="utf-8") as f: f.write(final_content + ('\n' if final_content else ''))
+        gr.Info(f"「{character_name}」のメモ帳を保存しました。"); return final_content
     except Exception as e:
-        gr.Error(f"メモ帳の保存エラー: {e}")
-        return content
+        gr.Error(f"メモ帳の保存エラー: {e}"); return content
+
 def handle_clear_notepad_click(character_name: str) -> str:
     if not character_name:
-        gr.Warning("キャラクターが選択されていません。")
-        return ""
-    _, _, _, _, notepad_path = character_manager.get_character_files_paths(character_name)
+        gr.Warning("キャラクターが選択されていません。"); return ""
+    _, _, _, _, notepad_path = get_character_files_paths(character_name)
     if not notepad_path:
-        gr.Error(f"「{character_name}」のメモ帳パス取得失敗。")
-        return ""
+        gr.Error(f"「{character_name}」のメモ帳パス取得失敗。"); return ""
     try:
-        with open(notepad_path, "w", encoding="utf-8") as f:
-            f.write("")
-        gr.Info(f"「{character_name}」のメモ帳を空にしました。")
-        return ""
+        with open(notepad_path, "w", encoding="utf-8") as f: f.write("")
+        gr.Info(f"「{character_name}」のメモ帳を空にしました。"); return ""
     except Exception as e:
-        gr.Error(f"メモ帳クリアエラー: {e}")
-        return f"エラー: {e}"
+        gr.Error(f"メモ帳クリアエラー: {e}"); return f"エラー: {e}"
+
 def handle_reload_notepad(character_name: str) -> str:
     if not character_name:
-        gr.Warning("キャラクターが選択されていません。")
-        return ""
+        gr.Warning("キャラクターが選択されていません。"); return ""
     content = load_notepad_content(character_name)
-    gr.Info(f"「{character_name}」のメモ帳を再読み込みしました。")
-    return content
+    gr.Info(f"「{character_name}」のメモ帳を再読み込みしました。"); return content
+
 def render_alarms_as_dataframe():
     alarms = sorted(alarm_manager.load_alarms(), key=lambda x: x.get("time", ""))
     all_rows = []
     for a in alarms:
-        theme_content = a.get("context_memo") or ""
-        date_str = a.get("date")
-        days_list = a.get("days", [])
         schedule_display = "単発"
-        if date_str:
+        if a.get("date"):
             try:
-                date_obj = datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
-                today = datetime.date.today()
+                date_obj, today = datetime.datetime.strptime(a["date"], "%Y-%m-%d").date(), datetime.date.today()
                 if date_obj == today: schedule_display = "今日"
                 elif date_obj == today + datetime.timedelta(days=1): schedule_display = "明日"
                 else: schedule_display = date_obj.strftime("%m/%d")
-            except:
-                schedule_display = "日付不定"
-        elif days_list:
-            schedule_display = ",".join([DAY_MAP_EN_TO_JA.get(d.lower(), d.upper()) for d in days_list])
-        all_rows.append({"ID": a.get("id"), "状態": a.get("enabled", False), "時刻": a.get("time"), "予定": schedule_display, "キャラ": a.get("character"), "内容": theme_content})
+            except: schedule_display = "日付不定"
+        elif a.get("days"): schedule_display = ",".join([DAY_MAP_EN_TO_JA.get(d.lower(), d.upper()) for d in a["days"]])
+        all_rows.append({"ID": a.get("id"), "状態": a.get("enabled", False), "時刻": a.get("time"), "予定": schedule_display, "キャラ": a.get("character"), "内容": a.get("context_memo") or ""})
     return pd.DataFrame(all_rows, columns=["ID", "状態", "時刻", "予定", "キャラ", "内容"])
+
 def get_display_df(df_with_id: pd.DataFrame):
-    if df_with_id is None or df_with_id.empty:
-        return pd.DataFrame(columns=["状態", "時刻", "予定", "キャラ", "内容"])
+    if df_with_id is None or df_with_id.empty: return pd.DataFrame(columns=["状態", "時刻", "予定", "キャラ", "内容"])
     return df_with_id[["状態", "時刻", "予定", "キャラ", "内容"]] if 'ID' in df_with_id.columns else df_with_id
+
 def handle_alarm_selection(evt: gr.SelectData, df_with_id: pd.DataFrame) -> List[str]:
     if not hasattr(evt, 'index') or evt.index is None or df_with_id is None or df_with_id.empty: return []
-    selected_ids = []
     indices = evt.index if isinstance(evt.index, list) else [evt.index]
-    for row_index in indices:
-        if isinstance(row_index, tuple): row_index = row_index[0]
-        if isinstance(row_index, int) and 0 <= row_index < len(df_with_id):
-            alarm_id = df_with_id.iloc[row_index]['ID']
-            selected_ids.append(str(alarm_id))
-    return selected_ids
+    return [str(df_with_id.iloc[r[0] if isinstance(r, tuple) else r]['ID']) for r in indices if isinstance(r, (int, tuple)) and 0 <= (r[0] if isinstance(r, tuple) else r) < len(df_with_id)]
+
 def handle_alarm_selection_for_all_updates(evt: gr.SelectData, df_with_id: pd.DataFrame):
     selected_ids = handle_alarm_selection(evt, df_with_id)
     feedback_text = "アラームを選択してください" if not selected_ids else f"{len(selected_ids)} 件のアラームを選択中"
-    all_chars = character_manager.get_character_list()
-    default_char = all_chars[0] if all_chars else "Default"
+    all_chars, default_char = character_manager.get_character_list(), "Default"
+    if all_chars: default_char = all_chars[0]
     if len(selected_ids) == 1:
-        alarm_id_to_load = selected_ids[0]
-        alarm = next((a for a in alarm_manager.load_alarms() if a.get("id") == alarm_id_to_load), None)
+        alarm = next((a for a in alarm_manager.load_alarms() if a.get("id") == selected_ids[0]), None)
         if alarm:
             h, m = alarm.get("time", "08:00").split(":")
-            days_list = alarm.get("days", [])
-            days_ja = [DAY_MAP_EN_TO_JA.get(d.lower(), d.upper()) for d in days_list]
-            theme_content = alarm.get("context_memo", "")
-            is_emergency = alarm.get("is_emergency", False)
-            form_updates = (
-                "アラーム更新", theme_content, "", alarm.get("character", default_char),
-                days_ja, is_emergency, h, m, alarm_id_to_load
-            )
-        else:
-            form_updates = ("アラーム追加", "", "", default_char, [], False, "08", "00", None)
-    else:
-        form_updates = ("アラーム追加", "", "", default_char, [], False, "08", "00", None)
+            days_ja = [DAY_MAP_EN_TO_JA.get(d.lower(), d.upper()) for d in alarm.get("days", [])]
+            form_updates = ("アラーム更新", alarm.get("context_memo", ""), "", alarm.get("character", default_char), days_ja, alarm.get("is_emergency", False), h, m, selected_ids[0])
+        else: form_updates = ("アラーム追加", "", "", default_char, [], False, "08", "00", None)
+    else: form_updates = ("アラーム追加", "", "", default_char, [], False, "08", "00", None)
     return (selected_ids, feedback_text) + form_updates
+
 def toggle_selected_alarms_status(selected_ids: list, target_status: bool):
-    if not selected_ids:
-        gr.Warning("状態を変更するアラームが選択されていません。")
-        df_with_ids = render_alarms_as_dataframe()
-        return df_with_ids, get_display_df(df_with_ids)
-    current_alarms = alarm_manager.load_alarms()
-    modified = False
-    for alarm in current_alarms:
-        if alarm.get("id") in selected_ids:
-            alarm["enabled"] = target_status
-            modified = True
-    if modified:
-        alarm_manager.alarms_data_global = current_alarms
-        alarm_manager.save_alarms()
-        gr.Info(f"{len(selected_ids)}件のアラームの状態を「{ '有効' if target_status else '無効' }」に変更しました。")
-    new_df_with_ids = render_alarms_as_dataframe()
-    return new_df_with_ids, get_display_df(new_df_with_ids)
-def handle_delete_selected_alarms(selected_ids: list):
-    if not selected_ids:
-        gr.Warning("削除するアラームが選択されていません。")
+    if not selected_ids: gr.Warning("状態を変更するアラームが選択されていません。")
     else:
-        for sid in selected_ids:
-            alarm_manager.delete_alarm(str(sid))
+        current_alarms = alarm_manager.load_alarms()
+        modified = any(a.get("id") in selected_ids and a.update({"enabled": target_status}) is None for a in current_alarms)
+        if modified:
+            alarm_manager.alarms_data_global = current_alarms
+            alarm_manager.save_alarms()
+            gr.Info(f"{len(selected_ids)}件のアラームの状態を「{'有効' if target_status else '無効'}」に変更しました。")
     new_df_with_ids = render_alarms_as_dataframe()
     return new_df_with_ids, get_display_df(new_df_with_ids)
+
+def handle_delete_selected_alarms(selected_ids: list):
+    if not selected_ids: gr.Warning("削除するアラームが選択されていません。")
+    else:
+        for sid in selected_ids: alarm_manager.delete_alarm(str(sid))
+    new_df_with_ids = render_alarms_as_dataframe()
+    return new_df_with_ids, get_display_df(new_df_with_ids)
+
 def handle_add_or_update_alarm(editing_id, h, m, char, theme, prompt, days_ja, is_emergency):
     from tools.alarm_tools import set_personal_alarm
-    time_str = f"{h}:{m}"
     context = theme or prompt or "時間になりました"
     days_en = [DAY_MAP_JA_TO_EN.get(d) for d in days_ja if d in DAY_MAP_JA_TO_EN]
     if editing_id:
-        alarm_manager.delete_alarm(editing_id)
-        gr.Info(f"アラームID:{editing_id}を更新します。")
-    set_personal_alarm.func(time=time_str, context_memo=context, character_name=char, days=days_en, date=None, is_emergency=is_emergency)
-    new_df_with_ids = render_alarms_as_dataframe()
-    all_chars = character_manager.get_character_list()
+        alarm_manager.delete_alarm(editing_id); gr.Info(f"アラームID:{editing_id}を更新します。")
+    set_personal_alarm.func(time=f"{h}:{m}", context_memo=context, character_name=char, days=days_en, date=None, is_emergency=is_emergency)
+    new_df_with_ids, all_chars = render_alarms_as_dataframe(), character_manager.get_character_list()
     default_char = all_chars[0] if all_chars else "Default"
-    return (
-        new_df_with_ids,
-        get_display_df(new_df_with_ids),
-        "アラーム追加",
-        "",
-        "",
-        gr.update(choices=all_chars, value=default_char),
-        [],
-        False,
-        "08",
-        "00",
-        None
-    )
+    return new_df_with_ids, get_display_df(new_df_with_ids), "アラーム追加", "", "", gr.update(choices=all_chars, value=default_char), [], False, "08", "00", None
+
 def handle_timer_submission(timer_type, duration, work, brk, cycles, char, work_theme, brk_theme, api_key_name, normal_theme):
-    if not char or not api_key_name:
-        return "エラー：キャラクターとAPIキーを選択してください。"
+    if not char or not api_key_name: return "エラー：キャラクターとAPIキーを選択してください。"
     try:
         timer = UnifiedTimer(timer_type, float(duration or 0), float(work or 0), float(brk or 0), int(cycles or 0), char, work_theme, brk_theme, api_key_name, normal_theme=normal_theme)
-        timer.start()
-        gr.Info(f"{timer_type}を開始しました.")
-        return f"{timer_type}を開始しました。"
-    except Exception as e:
-        return f"タイマー開始エラー: {e}"
+        timer.start(); gr.Info(f"{timer_type}を開始しました."); return f"{timer_type}を開始しました。"
+    except Exception as e: return f"タイマー開始エラー: {e}"
+
 def handle_rag_update_button_click(character_name: str, api_key_name: str):
     if not character_name or not api_key_name:
-        gr.Warning("キャラクターとAPIキーを選択してください。")
-        return
+        gr.Warning("キャラクターとAPIキーを選択してください。"); return
     api_key = config_manager.API_KEYS.get(api_key_name)
     if not api_key or api_key.startswith("YOUR_API_KEY"):
-        gr.Warning(f"APIキー '{api_key_name}' が有効ではありません。")
-        return
+        gr.Warning(f"APIキー '{api_key_name}' が有効ではありません。"); return
     gr.Info(f"「{character_name}」のRAG索引の更新を開始します...")
     import rag_manager
     threading.Thread(target=lambda: rag_manager.create_or_update_index(character_name, api_key)).start()
+
 def _run_core_memory_update(character_name: str, api_key: str):
     print(f"--- [スレッド開始] コアメモリ更新処理を開始します (Character: {character_name}) ---")
     try:
         result = memory_tools.summarize_and_save_core_memory.func(character_name=character_name, api_key=api_key)
         print(f"--- [スレッド終了] コアメモリ更新処理完了 --- 結果: {result}")
-    except Exception as e:
-        print(f"--- [スレッドエラー] コアメモリ更新中に予期せぬエラー ---")
-        traceback.print_exc()
+    except Exception: print(f"--- [スレッドエラー] コアメモリ更新中に予期せぬエラー ---"); traceback.print_exc()
+
 def handle_core_memory_update_click(character_name: str, api_key_name: str):
     if not character_name or not api_key_name:
-        gr.Warning("キャラクターとAPIキーを選択してください。")
-        return
+        gr.Warning("キャラクターとAPIキーを選択してください。"); return
     api_key = config_manager.API_KEYS.get(api_key_name)
     if not api_key or api_key.startswith("YOUR_API_KEY"):
-        gr.Warning(f"APIキー '{api_key_name}' が有効ではありません。")
-        return
+        gr.Warning(f"APIキー '{api_key_name}' が有効ではありません。"); return
     gr.Info(f"「{character_name}」のコアメモリ更新をバックグラウンドで開始しました。")
     threading.Thread(target=_run_core_memory_update, args=(character_name, api_key)).start()
+
 def update_model_state(model):
-    config_manager.save_config("last_model", model)
-    return model
+    config_manager.save_config("last_model", model); return model
+
 def update_api_key_state(api_key_name):
     config_manager.save_config("last_api_key_name", api_key_name)
-    gr.Info(f"APIキーを '{api_key_name}' に設定しました。")
-    return api_key_name
+    gr.Info(f"APIキーを '{api_key_name}' に設定しました。"); return api_key_name
+
 def update_timestamp_state(checked):
     config_manager.save_config("add_timestamp", bool(checked))
+
 def update_api_history_limit_state_and_reload_chat(limit_ui_val: str, character_name: Optional[str]):
     key = next((k for k, v in config_manager.API_HISTORY_LIMIT_OPTIONS.items() if v == limit_ui_val), "all")
     config_manager.save_config("last_api_history_limit_option", key)
     return key, reload_chat_log(character_name, key), gr.State()
+
 def handle_play_audio_button_click(selected_message: Optional[Dict[str, str]], character_name: str, api_key_name: str):
-    """外部コントロールパネルの再生ボタンが押されたときの処理"""
-    if not selected_message:
-        gr.Warning("再生するメッセージが選択されていません。")
-        return None
+    if not selected_message: gr.Warning("再生するメッセージが選択されていません。"); return None
     raw_text = utils.extract_raw_text_from_html(selected_message.get("content"))
     text_to_speak = utils.remove_thoughts_from_text(raw_text)
-    if not text_to_speak:
-        gr.Info("このメッセージには音声で再生できるテキストがありません。")
-        return None
+    if not text_to_speak: gr.Info("このメッセージには音声で再生できるテキストがありません。"); return None
     effective_settings = config_manager.get_effective_settings(character_name)
     voice_id = effective_settings.get("voice_id", "vindemiatrix")
     api_key = config_manager.API_KEYS.get(api_key_name)
-    if not api_key:
-        gr.Warning(f"APIキー '{api_key_name}' が見つかりません。")
-        return None
+    if not api_key: gr.Warning(f"APIキー '{api_key_name}' が見つかりません。"); return None
     from audio_manager import generate_audio_from_text
     gr.Info(f"「{character_name}」の声で音声を生成しています...")
     audio_filepath = generate_audio_from_text(text_to_speak, api_key, voice_id)
-    if audio_filepath:
-        gr.Info("再生します。")
-        return audio_filepath
-    else:
-        gr.Error("音声の生成に失敗しました。")
-        return None
+    if audio_filepath: gr.Info("再生します。"); return audio_filepath
+    else: gr.Error("音声の生成に失敗しました。"); return None
+
 def handle_voice_preview(selected_voice_name: str, text_to_speak: str, api_key_name: str):
-    """試聴ボタンが押されたときの処理"""
     if not selected_voice_name or not text_to_speak or not api_key_name:
-        gr.Warning("声、テキスト、APIキーがすべて選択されている必要があります。")
-        return None
+        gr.Warning("声、テキスト、APIキーがすべて選択されている必要があります。"); return None
     voice_id = next((key for key, value in config_manager.SUPPORTED_VOICES.items() if value == selected_voice_name), None)
     api_key = config_manager.API_KEYS.get(api_key_name)
-    if not voice_id or not api_key:
-        gr.Warning("声またはAPIキーが無効です。")
-        return None
+    if not voice_id or not api_key: gr.Warning("声またはAPIキーが無効です。"); return None
     from audio_manager import generate_audio_from_text
     gr.Info(f"声「{selected_voice_name}」で音声を生成しています...")
     audio_filepath = generate_audio_from_text(text_to_speak, api_key, voice_id)
-    if audio_filepath:
-        gr.Info("プレビューを再生します。")
-        return audio_filepath
-    else:
-        gr.Error("音声の生成に失敗しました。")
-        return None
+    if audio_filepath: gr.Info("プレビューを再生します。"); return audio_filepath
+    else: gr.Error("音声の生成に失敗しました。"); return None


### PR DESCRIPTION
This commit addresses a `gradio.exceptions.InvalidPathError` that occurred during conversations involving AI-generated images. The root cause was passing the `gr.Chatbot` component's state, which included server-side file paths, back to the server as an input. Gradio's security model correctly flagged these paths as invalid.

The fix refactors the application's data flow based on the following principles:

1.  **Decouple UI state from backend input**: The `gr.Chatbot` history is no longer passed as an input to the message submission handler (`handle_message_submission`).
2.  **Use a single source of truth**: The backend now exclusively loads the conversation history from the character's log file, ensuring data integrity.
3.  **Update dependent functions**: All related functions (`invoke_nexus_agent`, `trigger_alarm`) have been updated to align with this new log-file-based history approach.

These changes resolve the crash and create a more robust architecture, preventing similar UI state-related issues in the future.