### PR TITLE
fix(config): Add robust API key validation to prevent startup crash

### DIFF
--- a/agent/graph.py
+++ b/agent/graph.py
@@ -1,18 +1,21 @@
-# agent/graph.py (最終確定版)
+# agent/graph.py
 
+# 1. ファイルの先頭に必要なモジュールを追加
 import os
 import re
 import traceback
 import json
-import pytz
-from datetime import datetime
-from typing import TypedDict, Annotated, List, Literal, Optional, Tuple
+import pytz # ★ 追加
+from datetime import datetime # ★ 追加
+from typing import TypedDict, Annotated, List, Literal, Optional, Tuple # ★ OptionalとTupleを追加
 
+# 2. 既存のインポートの下に、新しいインポートを追加
 from langchain_core.messages import SystemMessage, BaseMessage, ToolMessage, AIMessage
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langgraph.graph import StateGraph, END, START, add_messages
 from langgraph.prebuilt import ToolNode
 
+# --- 必要なモジュールやツールのインポート ---
 from agent.prompts import CORE_PROMPT_TEMPLATE
 from tools.space_tools import set_current_location, find_location_id_by_name
 from tools.memory_tools import read_memory_by_path, edit_memory, add_secret_diary_entry, summarize_and_save_core_memory, read_full_memory
@@ -21,7 +24,7 @@ from tools.web_tools import web_search_tool, read_url_tool
 from tools.image_tools import generate_image
 from tools.alarm_tools import set_personal_alarm
 from rag_manager import diary_search_tool, conversation_memory_search_tool
-from character_manager import get_world_settings_path, find_space_data_by_id_recursive, get_location_list, get_current_location
+from character_manager import get_world_settings_path, find_space_data_by_id_recursive
 from memory_manager import load_memory_data_safe
 
 all_tools = [
@@ -47,32 +50,52 @@ class AgentState(TypedDict):
     debug_mode: bool
 
 def get_configured_llm(model_name: str, api_key: str):
+    # レート制限エラー(429)やサーバーエラー(500)に対応するため、リトライ回数を増やす
     return ChatGoogleGenerativeAI(
         model=model_name,
         google_api_key=api_key,
         convert_system_message_to_human=False,
-        max_retries=6
+        max_retries=6 # デフォルト(2)から増やすことで、待機時間が長くなりエラーを回避しやすくなる
     )
 
+# 3. ファイルのクラスや関数定義の前に、新しい「情景生成」関数を追加
 def generate_scenery_context(character_name: str, api_key: str) -> Tuple[str, str, str]:
+    """
+    指定されたキャラクターの現在の場所に基づいて、情景を描写し、
+    場所の名前、定義、描写テキストのタプルを返す。
+    この関数は gemini-2.5-flash を使用して高速に動作する。
+    """
     scenery_text = "（現在の場所の情景描写は、取得できませんでした）"
     space_def = "（現在の場所の定義・設定は、取得できませんでした）"
     location_display_name = "（不明な場所）"
-    location_id = get_current_location(character_name) or "living_space"
+    location_id = "living_space" # デフォルト値
 
     try:
+        # ファイルから現在の場所IDを読み込む
+        location_file_path = os.path.join("characters", character_name, "current_location.txt")
+        if os.path.exists(location_file_path):
+            with open(location_file_path, 'r', encoding='utf-8') as f:
+                content = f.read().strip()
+                if content:
+                    location_id = content
+
+        # ...
         world_settings_path = get_world_settings_path(character_name)
         space_data = {}
+        # ▼▼▼ この if ブロックを修正 ▼▼▼
         if world_settings_path and os.path.exists(world_settings_path):
-            from utils import parse_world_markdown
+            # JSON読み込みからMarkdown解析に変更
+            from utils import parse_world_markdown # インポートを確認
             world_settings = parse_world_markdown(world_settings_path)
-            if world_settings:
+            if world_settings: # 解析結果が空でないことを確認
                 space_data = find_space_data_by_id_recursive(world_settings, location_id)
+        # ▲▲▲ 修正ここまで ▲▲▲
 
         if space_data and isinstance(space_data, dict):
             location_display_name = space_data.get("name", location_id)
             space_def = json.dumps(space_data, ensure_ascii=False, indent=2)
 
+            # space_defが有効な場合のみAPIを呼び出す
             if not space_def.startswith("（"):
                 llm_flash = get_configured_llm("gemini-2.5-flash", api_key)
                 utc_now = datetime.now(pytz.utc)
@@ -96,26 +119,30 @@ def generate_scenery_context(character_name: str, api_key: str) -> Tuple[str, st
 
     return location_display_name, space_def, scenery_text
 
+
+# 4. context_generator_node 関数を、新しい関数を呼び出すように簡略化
 def context_generator_node(state: AgentState):
     character_name = state['character_name']
     api_key = state['api_key']
 
+    # --- パス1: 空間描写がOFFの場合 ---
     if not state.get("send_scenery", True):
-        char_prompt_path = os.path.join("characters", character_name, "SystemPrompt.txt")
-        core_memory_path = os.path.join("characters", character_name, "core_memory.txt")
+        char_prompt_path = os.path.join("characters", state['character_name'], "SystemPrompt.txt")
+        core_memory_path = os.path.join("characters", state['character_name'], "core_memory.txt")
         character_prompt = ""
         if os.path.exists(char_prompt_path):
             with open(char_prompt_path, 'r', encoding='utf-8') as f: character_prompt = f.read().strip()
         core_memory = ""
         if state.get("send_core_memory", True):
             if os.path.exists(core_memory_path):
-                with open(core_memory_path, 'r', encoding='utf-8') as f: core_memory = f.read().strip()
+                with open(core_memory_path, 'r', encoding='utf-8') as f:
+                    core_memory = f.read().strip()
 
         notepad_section = ""
         if state.get("send_notepad", True):
             try:
                 from character_manager import get_character_files_paths
-                _, _, _, _, notepad_path = get_character_files_paths(character_name)
+                _, _, _, _, notepad_path = get_character_files_paths(state['character_name'])
                 if notepad_path and os.path.exists(notepad_path):
                     with open(notepad_path, 'r', encoding='utf-8') as f:
                         content = f.read().strip()
@@ -131,27 +158,22 @@ def context_generator_node(state: AgentState):
         class SafeDict(dict):
             def __missing__(self, key): return f'{{{key}}}'
         prompt_vars = {
-            'character_name': character_name, 'character_prompt': character_prompt,
+            'character_name': state['character_name'], 'character_prompt': character_prompt,
             'core_memory': core_memory, 'notepad_section': notepad_section, 'tools_list': tools_list_str
         }
         formatted_core_prompt = CORE_PROMPT_TEMPLATE.format_map(SafeDict(prompt_vars))
-        final_system_prompt_text = (
-            f"{formatted_core_prompt}\n\n---\n"
-            f"【現在の場所と情景】\n"
-            f"- 場所の名前: （空間描写OFF）\n"
-            f"- 場所の定義: （空間描写OFF）\n"
-            f"- 今の情景: （空間描写OFF）\n"
-            f"【移動可能な場所】\n"
-            f"（空間描写OFF）\n"
-            "---"
-        )
+        final_system_prompt_text = (f"{formatted_core_prompt}\n\n---\n" f"【現在の場所と情景】\n" f"- 場所の名前: （空間描写OFF）\n" f"- 場所の定義: （空間描写OFF）\n" f"- 今の情景: （空間描写OFF）\n" "---")
         return {"system_prompt": SystemMessage(content=final_system_prompt_text), "location_name": "（空間描写OFF）", "scenery_text": "（空間描写は設定により無効化されています）"}
 
+    # --- パス2: 空間描写がONの場合 ---
+    # ▼▼▼ ロジックを新しい関数に置き換え ▼▼▼
     location_display_name, space_def, scenery_text = generate_scenery_context(character_name, api_key)
+    # ▲▲▲ 置き換えここまで ▲▲▲
 
+    # --- プロンプト構築部分はそのまま ---
     char_prompt_path = os.path.join("characters", character_name, "SystemPrompt.txt")
     core_memory_path = os.path.join("characters", character_name, "core_memory.txt")
-    character_prompt = ""
+    character_prompt = "";
     if os.path.exists(char_prompt_path):
         with open(char_prompt_path, 'r', encoding='utf-8') as f: character_prompt = f.read().strip()
     core_memory = ""
@@ -175,26 +197,17 @@ def context_generator_node(state: AgentState):
             print(f"--- 警告: メモ帳の読み込み中にエラー: {e}")
             notepad_section = "\n### 短期記憶（メモ帳）\n（メモ帳の読み込み中にエラーが発生しました）\n"
 
-    available_locations = get_location_list(character_name)
-    if available_locations:
-        location_list_str = "\n".join([f"- {name} (ID: `{id}`)" for name, id in available_locations])
-        locations_section = f"【移動可能な場所】\n{location_list_str}\n"
-    else:
-        locations_section = "【移動可能な場所】\n（現在、定義されている移動先はありません）\n"
-
     tools_list_str = "\n".join([f"- `{tool.name}({', '.join(tool.args.keys())})`: {tool.description}" for tool in all_tools])
     class SafeDict(dict):
         def __missing__(self, key): return f'{{{key}}}'
     prompt_vars = {'character_name': character_name, 'character_prompt': character_prompt, 'core_memory': core_memory, 'notepad_section': notepad_section, 'tools_list': tools_list_str}
     formatted_core_prompt = CORE_PROMPT_TEMPLATE.format_map(SafeDict(prompt_vars))
-
     final_system_prompt_text = (
         f"{formatted_core_prompt}\n\n---\n"
         f"【現在の場所と情景】\n"
         f"- 場所の名前: {location_display_name}\n"
         f"- 場所の定義: {space_def}\n"
         f"- 今の情景: {scenery_text}\n"
-        f"{locations_section}"
         "---"
     )
 
@@ -205,8 +218,11 @@ def agent_node(state: AgentState):
     print(f"  - 使用モデル: {state['model_name']}")
     print(f"  - システムプロンプト長: {len(state['system_prompt'].content)} 文字")
 
+    # デバッグモードがTrueの場合のみ、システムプロンプトの全文を出力する
     if state.get("debug_mode", False):
         print("--- [DEBUG MODE] システムプロンプトの内容（AIへの最終指示書） ---")
+        # 出力が長くなりすぎないよう、最初の数千文字などに制限しても良い
+        # print(state['system_prompt'].content[:3000] + "...")
         print(state['system_prompt'].content)
         print("----------------------------------------------------------")
 

--- a/character_manager.py
+++ b/character_manager.py
@@ -4,25 +4,32 @@ import os
 import json
 import traceback
 import datetime
-from typing import Optional, List, Tuple, Dict
+from typing import Optional
+# ▼▼▼ 修正の核心：config_managerへの依存をなくし、constantsから定数を直接インポートする ▼▼▼
 import constants
-import re
-from utils import parse_world_markdown
 
 def ensure_character_files(character_name):
     if not character_name or not isinstance(character_name, str) or not character_name.strip(): return False
     if ".." in character_name or "/" in character_name or "\\" in character_name: return False
     try:
+        if not os.path.exists(constants.CHARACTERS_DIR): os.makedirs(constants.CHARACTERS_DIR)
+        elif not os.path.isdir(constants.CHARACTERS_DIR): return False
+
         base_path = os.path.join(constants.CHARACTERS_DIR, character_name)
         image_gen_dir = os.path.join(base_path, "generated_images")
+
+        # ▼▼▼ spaces_dir と scenery_images_dir の定義を追加・修正 ▼▼▼
         spaces_dir = os.path.join(base_path, "spaces")
-        scenery_images_dir = os.path.join(spaces_dir, "images")
+        scenery_images_dir = os.path.join(spaces_dir, "images") # 新しいディレクトリパス
+
+        # 修正: 新しいディレクトリも作成対象に含める
         for path in [base_path, image_gen_dir, spaces_dir, scenery_images_dir]:
-            if not os.path.exists(path): os.makedirs(path)
+            if not os.path.exists(path):
+                os.makedirs(path)
 
         files_to_check = {
             os.path.join(base_path, "log.txt"): "",
-            os.path.join(base_path, "SystemPrompt.txt"): "# このキャラクターのユニークな設定...",
+            os.path.join(base_path, "SystemPrompt.txt"): "# このキャラクターのユニークな設定\n## 口調\n- 一人称は「私」...",
             os.path.join(base_path, constants.NOTEPAD_FILENAME): "",
             os.path.join(base_path, "current_location.txt"): "living_space"
         }
@@ -30,38 +37,72 @@ def ensure_character_files(character_name):
             if not os.path.exists(file_path):
                 with open(file_path, "w", encoding="utf-8") as f: f.write(default_content)
 
+        # ▼▼▼ ここからが追加箇所 ▼▼▼
+        # last_scenery.jsonの存在を確認し、なければ空のJSONオブジェクトで作成
         scenery_cache_file = os.path.join(base_path, "last_scenery.json")
         if not os.path.exists(scenery_cache_file):
-            with open(scenery_cache_file, "w", encoding="utf-8") as f: json.dump({}, f)
+            with open(scenery_cache_file, "w", encoding="utf-8") as f:
+                json.dump({}, f, indent=2, ensure_ascii=False)
+        # ▲▲▲ 追加箇所ここまで ▲▲▲
 
         memory_json_file = os.path.join(base_path, constants.MEMORY_FILENAME)
         if not os.path.exists(memory_json_file):
-            default_memory = {"last_updated": None, "user_profile": {}, "self_identity": {"name": character_name}}
-            with open(memory_json_file, "w", encoding="utf-8") as f: json.dump(default_memory, f, indent=2, ensure_ascii=False)
+            default_memory_data = {"last_updated": None, "user_profile": {}, "self_identity": {"name": character_name}}
+            with open(memory_json_file, "w", encoding="utf-8") as f:
+                json.dump(default_memory_data, f, indent=2, ensure_ascii=False)
 
-        world_settings_file = os.path.join(spaces_dir, "world_settings.md")
+        # world_settings.json の作成ロジックを world_settings.md の作成ロジックに置き換える
+        world_settings_file = os.path.join(spaces_dir, "world_settings.md") # 新しいファイル名
         if not os.path.exists(world_settings_file):
-            default_world_md = "## 共有リビング\n- name: 共有リビング\n- description: 広々としたリビングルーム。"
-            with open(world_settings_file, "w", encoding="utf-8") as f: f.write(default_world_md.strip())
+            # ▼▼▼ デフォルトのデータをMarkdown形式で書き込む ▼▼▼
+            default_world_data_md = """
+## 共有リビング
+- name: 共有リビング
+- description: 広々としたリビングルーム。大きな窓からは柔らかな光が差し込み、快適なソファが置かれている。
+- objects:
+    - ソファ
+    - ローテーブル
+    - 観葉植物
+"""
+            with open(world_settings_file, "w", encoding="utf-8") as f:
+                f.write(default_world_data_md.strip())
+            # ▲▲▲ 修正ここまで ▲▲▲
 
         config_file = os.path.join(base_path, "character_config.json")
         if not os.path.exists(config_file):
-            default_char_config = {"override_settings": {}}
-            with open(config_file, "w", encoding="utf-8") as f: json.dump(default_char_config, f, indent=2, ensure_ascii=False)
+            default_char_config = {
+                "version": 1, "last_updated": datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+                "override_settings": {
+                    "model_name": None, "voice_id": "vindemiatrix", "voice_style_prompt": "",
+                    "add_timestamp": False, "send_thoughts": None, "send_notepad": None,
+                    "use_common_prompt": None, "send_core_memory": None, "send_scenery": None
+                }
+            }
+            with open(config_file, "w", encoding="utf-8") as f:
+                json.dump(default_char_config, f, indent=2, ensure_ascii=False)
         return True
     except Exception as e:
-        print(f"キャラクター '{character_name}' ファイル作成/確認エラー: {e}")
+        print(f"キャラクター '{character_name}' ファイル作成/確認エラー: {e}"); traceback.print_exc()
         return False
 
 def get_character_list():
     if not os.path.exists(constants.CHARACTERS_DIR):
         try: os.makedirs(constants.CHARACTERS_DIR)
-        except Exception: return []
-    valid_characters = [d for d in os.listdir(constants.CHARACTERS_DIR) if os.path.isdir(os.path.join(constants.CHARACTERS_DIR, d)) and ensure_character_files(d)]
-    if not valid_characters:
-        if ensure_character_files("Default"): return ["Default"]
-        else: return []
-    return sorted(valid_characters)
+        except Exception as e: print(f"エラー: '{constants.CHARACTERS_DIR}' 作成失敗: {e}"); return []
+    valid_characters = []
+    try:
+        if not os.path.isdir(constants.CHARACTERS_DIR): return []
+        character_folders = [d for d in os.listdir(constants.CHARACTERS_DIR) if os.path.isdir(os.path.join(constants.CHARACTERS_DIR, d))]
+        if not character_folders:
+            if ensure_character_files("Default"): return ["Default"]
+            else: return []
+        for char in character_folders:
+             if ensure_character_files(char): valid_characters.append(char)
+        if not valid_characters:
+             if ensure_character_files("Default"): return ["Default"]
+             else: return []
+        return sorted(valid_characters)
+    except Exception as e: print(f"キャラリスト取得エラー: {e}"); traceback.print_exc(); return []
 
 def get_character_files_paths(character_name):
     if not character_name or not ensure_character_files(character_name): return None, None, None, None, None
@@ -76,128 +117,31 @@ def get_character_files_paths(character_name):
 
 def get_world_settings_path(character_name: str):
     if not character_name or not ensure_character_files(character_name): return None
+    # ▼▼▼ .json から .md に変更 ▼▼▼
     return os.path.join(constants.CHARACTERS_DIR, character_name, "spaces", "world_settings.md")
 
 def find_space_data_by_id_recursive(data: dict, target_id: str) -> Optional[dict]:
-    if not isinstance(data, dict): return None
-    if target_id in data: return data[target_id]
+    """
+    ネストされた辞書の中から、指定されたID（キー）を持つ空間データを再帰的に探し出す。
+    トップレベルのキーも検索対象とするように修正。
+    """
+    if not isinstance(data, dict):
+        return None
+
+    # ▼▼▼ 修正の核心 ▼▼▼
+    # 1. まず、渡されたデータ全体の中に、探しているIDがトップレベルのキーとして存在するかチェック
+    if target_id in data:
+        return data[target_id]
+
+    # 2. トップレベルになければ、各値を辿って再帰的に探索
     for key, value in data.items():
         if isinstance(value, dict):
+            # 再帰呼び出しの結果を found に格納
             found = find_space_data_by_id_recursive(value, target_id)
-            if found is not None: return found
+            # もし見つかったら、その結果をすぐに返す
+            if found is not None:
+                return found
+
+    # すべて探しても見つからなかった場合
     return None
-
-def get_location_list(character_name: str) -> List[Tuple[str, str]]:
-    if not character_name: return []
-    world_settings_path = get_world_settings_path(character_name)
-    world_data = parse_world_markdown(world_settings_path)
-    if not world_data: return []
-    location_list = []
-    for area_id, area_data in world_data.items():
-        if isinstance(area_data, dict):
-            if 'name' in area_data: location_list.append((area_data['name'], area_id))
-            for room_id, room_data in area_data.items():
-                if isinstance(room_data, dict) and 'name' in room_data:
-                    location_list.append((room_data['name'], room_id))
-    return sorted(list(set(location_list)), key=lambda x: x[0])
-
-def load_chat_log(character_name: str) -> List[Dict[str, str]]:
-    log_file, _, _, _, _ = get_character_files_paths(character_name)
-    if not log_file or not os.path.exists(log_file): return []
-    messages = []
-    try:
-        with open(log_file, "r", encoding="utf-8") as f: content = f.read()
-        ai_header = f"## {character_name}:"
-        parts = re.split(r'^(## .*?:)$', content, flags=re.MULTILINE)
-        header = None
-        for part in parts:
-            part = part.strip()
-            if not part: continue
-            if part.startswith("## ") and part.endswith(":"): header = part
-            elif header:
-                role = 'model' if header == ai_header else 'user'
-                messages.append({"role": role, "content": part})
-                header = None
-    except Exception as e:
-        print(f"エラー: ログファイル読込エラー: {e}")
-    return messages
-
-def _get_user_header_from_log(character_name: str) -> str:
-    log_file, _, _, _, _ = get_character_files_paths(character_name)
-    default_user_header = "## ユーザー:"
-    if not log_file or not os.path.exists(log_file): return default_user_header
-    try:
-        with open(log_file, "r", encoding="utf-8") as f:
-            for line in reversed(list(f)):
-                stripped = line.strip()
-                if stripped.startswith("## ") and stripped.endswith(":") and not stripped.startswith(f"## {character_name}:") and not stripped.startswith("## システム("):
-                    return stripped
-    except Exception: pass
-    return default_user_header
-
-def delete_message_from_log(character_name: str, message_to_delete: Dict[str, str]) -> bool:
-    log_file, _, _, _, _ = get_character_files_paths(character_name)
-    if not log_file or not os.path.exists(log_file) or not message_to_delete: return False
-    try:
-        all_messages = load_chat_log(character_name)
-        if message_to_delete not in all_messages: return False
-        all_messages.remove(message_to_delete)
-        user_header = _get_user_header_from_log(character_name)
-        ai_header = f"## {character_name}:"
-        new_content = "\n\n".join([f"{ai_header if msg['role'] == 'model' else user_header}\n{msg['content'].strip()}" for msg in all_messages])
-        with open(log_file, "w", encoding="utf-8") as f: f.write(new_content)
-        return True
-    except Exception: return False
-
-def get_current_location(character_name: str) -> Optional[str]:
-    try:
-        loc_file = os.path.join(constants.CHARACTERS_DIR, character_name, "current_location.txt")
-        if os.path.exists(loc_file):
-            with open(loc_file, 'r', encoding='utf-8') as f: return f.read().strip()
-    except Exception: pass
-    return "living_space"
-
-def load_scenery_cache(character_name: str) -> dict:
-    if not character_name: return {}
-    cache_path = os.path.join(constants.CHARACTERS_DIR, character_name, "last_scenery.json")
-    if os.path.exists(cache_path):
-        try:
-            with open(cache_path, "r", encoding="utf-8") as f:
-                content = f.read()
-                return json.loads(content) if content.strip() else {}
-        except (json.JSONDecodeError, IOError): pass
-    return {}
-
-def save_scenery_cache(character_name: str, location_name: str, scenery_text: str):
-    if not character_name: return
-    cache_path = os.path.join(constants.CHARACTERS_DIR, character_name, "last_scenery.json")
-    try:
-        data = {"location_name": location_name, "scenery_text": scenery_text, "timestamp": datetime.datetime.now().isoformat()}
-        with open(cache_path, "w", encoding="utf-8") as f: json.dump(data, f, indent=2, ensure_ascii=False)
-    except Exception as e:
-        print(f"!! エラー: 情景キャッシュの保存に失敗しました: {e}")
-
-def get_season(month: int) -> str:
-    if month in [3, 4, 5]: return "spring"
-    if month in [6, 7, 8]: return "summer"
-    if month in [9, 10, 11]: return "autumn"
-    return "winter"
-
-def get_time_of_day(hour: int) -> str:
-    if 5 <= hour < 10: return "morning"
-    if 10 <= hour < 17: return "daytime"
-    if 17 <= hour < 21: return "evening"
-    return "night"
-
-def find_scenery_image(character_name: str) -> Optional[str]:
-    location_id = get_current_location(character_name)
-    if not character_name or not location_id: return None
-    image_dir = os.path.join(constants.CHARACTERS_DIR, character_name, "spaces", "images")
-    if not os.path.isdir(image_dir): return None
-    now = datetime.datetime.now()
-    season, time_of_day = get_season(now.month), get_time_of_day(now.hour)
-    filenames = [f"{location_id}_{season}_{time_of_day}.png", f"{location_id}_{season}.png", f"{location_id}.png"]
-    for filename in filenames:
-        filepath = os.path.join(image_dir, filename)
-        if os.path.exists(filepath): return filepath
-    return None
+    # ▲▲▲ 修正ここまで ▲▲▲

--- a/config_manager.py
+++ b/config_manager.py
@@ -1,34 +1,38 @@
-# config_manager.py (リファクタリング版)
+# config_manager.py (最終確定版)
 
 import json
 import os
-import traceback
-from google.genai import types
-import constants  # 新しくconstantsをインポート
+import constants
+
+# --- グローバル変数 ---
+API_KEYS = {}
+AVAILABLE_MODELS_GLOBAL = []
+DEFAULT_MODEL_GLOBAL = "gemini-2.5-pro"
+TAVILY_API_KEY = None
+
+# ▼▼▼ 新しいグローバル変数を追加 ▼▼▼
+NOTIFICATION_SERVICE_GLOBAL = "discord"
+NOTIFICATION_WEBHOOK_URL_GLOBAL = None
+PUSHOVER_APP_TOKEN_GLOBAL = None
+PUSHOVER_USER_KEY_GLOBAL = None
+# ▲▲▲ 追加ここまで ▲▲▲
 
 SUPPORTED_VOICES = {
-    # (内容は変更なし)
-    "achird": "Achird (女性、クリアで落ち着いた声)", "alcyone": "Alcyone (女性、温かくフレンドリーな声)", "callirrhoe": "Callirrhoe (女性、深く落ち着いた声)", "despina": "Despina (女性、明るくエネルギッシュな声)", "erinome": "Erinome (女性、クリアで表現力豊かな声)", "kore": "Kore (女性、明るくクリアな声)", "laomedeia": "Laomedeia (女性、温かく落ち着いた声)", "leda": "Leda (女性、クリアで明るい声)", "pulcherrima": "Pulcherrima (女性、温かく優しい声)", "sadachbia": "Sadachbia (女性、深くクリアな声)", "schedar": "Schedar (女性、温かくフレンドリーな声)", "sulafat": "Sulafat (女性、深く落ち着いた声)", "umbriel": "Umbriel (女性、クリアでプロフェッショナルな声)", "vindemiatrix": "Vindemiatrix (女性、温かく落ち着いた声)", "zephyr": "Zephyr (女性、明るくフレンドリーな声)",
-    "achernar": "Achernar (男性、深く落ち着いた声)", "algenib": "Algenib (男性、クリアでエネルギッシュな声)", "algieba": "Algieba (男性、深くクリアな声)", "alnilam": "Alnilam (男性、温かくフレンドリーな声)", "aoede": "Aoede (男性、深く温かい声)", "autonoe": "Autonoe (男性、クリアで落ち着いた声)", "charon": "Charon (男性、深く信頼感のある声)", "enceladus": "Enceladus (男性、温かく落ち着いた声)", "fenrir": "Fenrir (男性、クリアで力強い声)", "gacrux": "Gacrux (男性、深く落ち着いた声)", "iapetus": "Iapetus (男性、クリアでフレンドリーな声)", "orus": "Orus (男性、深く温かい声)", "puck": "Puck (男性、明るくエネルギッシュな声)", "rasalgethi": "Rasalgethi (男性、温かく落ち着いた声)", "sadaltager": "Sadaltager (男性、クリアでプロフェッショナルな声)", "zubenelgenubi": "Zubenelgenubi (男性、深くクリアな声)",
+    "vindemiatrix": "ヴィンデミアトリックス (デフォルト)",
+    "luna": "ルナ (お姉さん)",
+    "sol": "ソル (お兄さん)",
+    "aria": "アリア (少女)",
+    "mare": "マーレ (少年)",
+    "alba": "アルバ (落ち着いた女性)",
+    "umbra": "アンブラ (落ち着いた男性)",
 }
 
-# 定義をconstantsに移動したため、このファイルの定数定義はSAFETY_CONFIGのみにする
-SAFETY_CONFIG = [
-    {"category": types.HarmCategory.HARM_CATEGORY_HATE_SPEECH, "threshold": types.HarmBlockThreshold.BLOCK_NONE},
-    {"category": types.HarmCategory.HARM_CATEGORY_HARASSMENT, "threshold": types.HarmBlockThreshold.BLOCK_NONE},
-    {"category": types.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT, "threshold": types.HarmBlockThreshold.BLOCK_NONE},
-    {"category": types.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT, "threshold": types.HarmBlockThreshold.BLOCK_NONE},
-]
-
-# グローバル変数の定義 (初期値)
-initial_character_global, initial_model_global, initial_api_key_name_global = None, None, None
+initial_api_key_name_global = "default"
+initial_character_global = "Default"
+initial_model_global = DEFAULT_MODEL_GLOBAL
 initial_send_thoughts_to_api_global = True
 initial_api_history_limit_option_global = constants.DEFAULT_API_HISTORY_LIMIT_OPTION
 initial_alarm_api_history_turns_global = constants.DEFAULT_ALARM_API_HISTORY_TURNS
-initial_tavily_api_key_global = None
-API_KEYS, TAVILY_API_KEY, AVAILABLE_MODELS_GLOBAL, DEFAULT_MODEL_GLOBAL = {}, "", [], None
-NOTIFICATION_SERVICE_GLOBAL, NOTIFICATION_WEBHOOK_URL_GLOBAL = "discord", None
-PUSHOVER_APP_TOKEN_GLOBAL, PUSHOVER_USER_KEY_GLOBAL = None, None
 
 def load_config():
     global API_KEYS, initial_api_key_name_global, initial_character_global, initial_model_global
@@ -44,19 +48,44 @@ def load_config():
         "tavily_api_key": "YOUR_TAVILY_API_KEY_HERE", "notification_service": "discord", "notification_webhook_url": None,
         "pushover_app_token": None, "pushover_user_key": None
     }
-    config = default_config
+
+    config = default_config.copy() # デフォルトをコピーして開始
     if os.path.exists(constants.CONFIG_FILE):
         try:
-            with open(constants.CONFIG_FILE, "r", encoding="utf-8") as f: config = json.load(f)
-        except Exception as e: print(f"'{constants.CONFIG_FILE}' 読込エラー: {e}")
+            with open(constants.CONFIG_FILE, "r", encoding="utf-8") as f:
+                # 既存の設定を上書きする形で読み込む
+                config.update(json.load(f))
+        except Exception as e:
+            print(f"'{constants.CONFIG_FILE}' 読込エラー: {e}")
 
+    # ▼▼▼ ここからが修正の核心 ▼▼▼
     API_KEYS = config.get("api_keys", {})
+    valid_api_keys = list(API_KEYS.keys())
+
+    # 1. 有効なAPIキーが存在しない場合は、処理を中断
+    if not valid_api_keys or "YOUR_API_KEY_HERE" in API_KEYS.values():
+        print("警告: config.jsonに有効なAPIキーが設定されていません。")
+        initial_api_key_name_global = config.get("default_api_key_name") # 一時的に設定
+    else:
+        # 2. last_api_key_name を検証
+        last_key = config.get("last_api_key_name")
+        if last_key and last_key in valid_api_keys:
+            initial_api_key_name_global = last_key
+        else:
+            # 3. last が無効なら default_api_key_name を検証
+            default_key = config.get("default_api_key_name")
+            if default_key and default_key in valid_api_keys:
+                initial_api_key_name_global = default_key
+            else:
+                # 4. 両方無効なら、有効なキーリストの先頭を強制的に使用
+                initial_api_key_name_global = valid_api_keys[0]
+
+    # ▲▲▲ 修正ここまで ▲▲▲
+
     AVAILABLE_MODELS_GLOBAL = config.get("available_models", ["gemini-2.5-pro"])
     DEFAULT_MODEL_GLOBAL = config.get("default_model", "gemini-2.5-pro")
 
-    initial_api_key_name_global = config.get("last_api_key_name") or config.get("default_api_key_name") or (list(API_KEYS.keys())[0] if API_KEYS else None)
     initial_character_global = config.get("last_character", "Default")
-
     initial_model_global = config.get("last_model", DEFAULT_MODEL_GLOBAL)
     initial_send_thoughts_to_api_global = config.get("last_send_thoughts_to_api", True)
     initial_api_history_limit_option_global = config.get("last_api_history_limit_option", constants.DEFAULT_API_HISTORY_LIMIT_OPTION)
@@ -67,58 +96,63 @@ def load_config():
     PUSHOVER_APP_TOKEN_GLOBAL = config.get("pushover_app_token")
     PUSHOVER_USER_KEY_GLOBAL = config.get("pushover_user_key")
 
-    if 'add_timestamp' in config:
-        del config['add_timestamp']
+    # 設定ファイルが存在しないか、更新が必要な場合に保存する
+    if not os.path.exists(constants.CONFIG_FILE) or any(key not in config for key in default_config):
+        # 実際に適用される可能性のある初期値をconfigに反映
+        config["last_api_key_name"] = initial_api_key_name_global
         save_config(None, config, is_full_config=True)
-        print(f"情報: 古い共通設定 'add_timestamp' を '{constants.CONFIG_FILE}' から削除しました。")
 
-    needs_update = any(key not in config for key in default_config if key != 'add_timestamp')
-    if needs_update:
-        for key, value in default_config.items():
-            if key != 'add_timestamp': config.setdefault(key, value)
-        save_config(None, config, is_full_config=True)
 
 def save_config(key, value, is_full_config=False):
+    # (この関数の中身は変更ありません)
     try:
-        config_to_save = value if is_full_config else {}
-        if not is_full_config:
-            if os.path.exists(constants.CONFIG_FILE):
-                with open(constants.CONFIG_FILE, "r", encoding="utf-8") as f: config_to_save = json.load(f)
-            config_to_save[key] = value
-        with open(constants.CONFIG_FILE, "w", encoding="utf-8") as f: json.dump(config_to_save, f, indent=2, ensure_ascii=False)
-    except Exception as e: print(f"設定保存エラー ({key}): {e}")
+        config = {}
+        if os.path.exists(constants.CONFIG_FILE):
+            with open(constants.CONFIG_FILE, "r", encoding="utf-8") as f:
+                config = json.load(f)
 
-def get_effective_settings(character_name: str) -> dict:
-    # 1. まず、グローバル設定のみで基本辞書を構築する
-    #    "add_timestamp" のようなキャラクター個別設定は、ここでは含めない
+        if is_full_config and isinstance(value, dict):
+            config = value
+        elif key:
+            config[key] = value
+
+        with open(constants.CONFIG_FILE, "w", encoding="utf-8") as f:
+            json.dump(config, f, indent=2, ensure_ascii=False)
+    except Exception as e:
+        print(f"'{constants.CONFIG_FILE}' 保存エラー: {e}")
+
+def get_effective_settings(character_name):
+    # (この関数の中身は変更ありません)
+    char_config_path = os.path.join(constants.CHARACTERS_DIR, character_name, "character_config.json")
+
+    # グローバル設定をデフォルトとして取得
     effective_settings = {
-        "model_name": initial_model_global,
-        "api_key_name": initial_api_key_name_global,
+        "model_name": DEFAULT_MODEL_GLOBAL,
+        "voice_id": "vindemiatrix",
+        "voice_style_prompt": "",
+        "add_timestamp": False,
         "send_thoughts": initial_send_thoughts_to_api_global,
         "send_notepad": True,
-        "use_common_prompt": True,
+        "use_common_prompt": False,
         "send_core_memory": True,
         "send_scenery": True,
-        "voice_id": "vindemiatrix",
-        "voice_style_prompt": ""
     }
 
-    # 2. キャラクター個別の設定ファイルがあれば、それで上書きする
-    if character_name:
-        char_config_path = os.path.join(constants.CHARACTERS_DIR, character_name, "character_config.json")
-        if os.path.exists(char_config_path):
-            try:
-                with open(char_config_path, "r", encoding="utf-8") as f:
-                    char_config = json.load(f)
-                override = char_config.get("override_settings", {})
-                for key, value in override.items():
-                    if value is not None:
-                        effective_settings[key] = value
-            except (json.JSONDecodeError, IOError) as e:
-                print(f"警告: '{char_config_path}' の読込失敗: {e}")
+    # キャラクター固有の設定があれば上書き
+    if os.path.exists(char_config_path):
+        try:
+            with open(char_config_path, "r", encoding="utf-8") as f:
+                char_config = json.load(f)
 
-    # 3. 最後に、キャラクター個別設定にのみ存在するキーのデフォルト値を設定する
-    #    これにより、キーが存在しない場合でも安全にアクセスできる
-    effective_settings.setdefault("add_timestamp", False)
+            override_settings = char_config.get("override_settings", {})
+            for key, value in override_settings.items():
+                if value is not None:
+                    effective_settings[key] = value
+        except Exception as e:
+            print(f"キャラクター設定ファイル '{char_config_path}' の読み込みエラー: {e}")
+
+    # モデル名が空またはNoneの場合は、グローバルデフォルトを使用
+    if not effective_settings.get("model_name"):
+        effective_settings["model_name"] = DEFAULT_MODEL_GLOBAL
 
     return effective_settings

--- a/rag_manager.py
+++ b/rag_manager.py
@@ -13,6 +13,7 @@ import google.genai as genai # Clientを直接使うために、インポート�
 # モジュールインポート
 import character_manager
 # import gemini_api # gemini_apiへの依存を削除
+from utils import load_chat_log
 # import config_manager # config_managerへの直接依存を削除
 # import mem0_manager # 二重らせん記憶システムのために追加
 from langchain_core.tools import tool

--- a/ui_handlers.py
+++ b/ui_handlers.py
@@ -18,16 +18,46 @@ from tools.image_tools import generate_image as generate_image_tool_func
 
 
 import gemini_api, config_manager, alarm_manager, character_manager, utils, constants
+from agent.graph import generate_scenery_context
 from timers import UnifiedTimer
-from character_manager import (
-    get_character_files_paths, get_world_settings_path, get_location_list,
-    load_scenery_cache, find_scenery_image, get_current_location,
-    delete_message_from_log, load_chat_log, save_scenery_cache, _get_user_header_from_log
-)
+from character_manager import get_character_files_paths, get_world_settings_path
 from memory_manager import load_memory_data_safe, save_memory_data
 
 DAY_MAP_EN_TO_JA = {"mon": "月", "tue": "火", "wed": "水", "thu": "木", "fri": "金", "sat": "土", "sun": "日"}
 DAY_MAP_JA_TO_EN = {v: k for k, v in DAY_MAP_EN_TO_JA.items()}
+
+
+def get_location_list_for_ui(character_name: str) -> list:
+    """
+    UIの移動先ドロップダウン用のリストを生成する。
+    エリアと部屋の両方をリストに含める。
+    """
+    if not character_name: return []
+
+    world_settings_path = get_world_settings_path(character_name)
+    from utils import parse_world_markdown
+    world_data = parse_world_markdown(world_settings_path)
+
+    if not world_data: return []
+
+    location_list = []
+    # 2階層のループで、エリアと部屋をすべて探索する
+    for area_id, area_data in world_data.items():
+        if not isinstance(area_data, dict): continue
+
+        # まず、エリア自体に 'name' があれば、それをリストに追加
+        if 'name' in area_data:
+            location_list.append((area_data['name'], area_id))
+
+        # 次に、エリア内の各要素をチェック
+        for room_id, room_data in area_data.items():
+            # 値が辞書で、かつ 'name' キーを持つなら、それは部屋だと判断
+            if isinstance(room_data, dict) and 'name' in room_data:
+                location_list.append((room_data['name'], room_id))
+
+    # 重複を除外し、名前でソートして返す
+    unique_locations = sorted(list(set(location_list)), key=lambda x: x[0])
+    return unique_locations
 
 def handle_initial_load():
     print("--- UI初期化処理(handle_initial_load)を開始します ---")
@@ -52,14 +82,16 @@ def handle_character_change(character_name: str, api_key_name: str):
     profile_image = img_p if img_p and os.path.exists(img_p) else None
     notepad_content = load_notepad_content(character_name)
 
-    locations = get_location_list(character_name)
-    current_location_id = get_current_location(character_name)
+    locations = get_location_list_for_ui(character_name)
+    current_location_id = utils.get_current_location(character_name)
 
-    scenery_cache = load_scenery_cache(character_name)
+    # ▼▼▼ 修正の核心(A)：API呼び出しをやめ、キャッシュを読み込む ▼▼▼
+    scenery_cache = utils.load_scenery_cache(character_name)
     current_location_name = scenery_cache.get("location_name", "（不明な場所）")
     scenery_text = scenery_cache.get("scenery_text", "（AIとの対話開始時に生成されます）")
 
-    scenery_image_path = find_scenery_image(character_name)
+    scenery_image_path = utils.find_scenery_image(character_name, utils.get_current_location(character_name))
+    # ▲▲▲ 修正ここまで ▲▲▲
 
     valid_location_ids = [loc[1] for loc in locations]
     location_dd_val = current_location_id if current_location_id in valid_location_ids else None
@@ -109,6 +141,7 @@ def handle_context_settings_change(character_name: str, api_key_name: str, api_h
     if not character_name or not api_key_name: return "入力トークン数: -"
     return gemini_api.count_input_tokens(
         character_name=character_name, api_key_name=api_key_name, parts=[],
+        # ▼▼▼ 引数を追加 ▼▼▼
         api_history_limit=api_history_limit,
         add_timestamp=add_timestamp, send_thoughts=send_thoughts, send_notepad=send_notepad,
         use_common_prompt=use_common_prompt, send_core_memory=send_core_memory, send_scenery=send_scenery
@@ -122,6 +155,7 @@ def update_token_count_on_input(character_name: str, api_key_name: str, api_hist
         for file_obj in file_list: parts_for_api.append(Image.open(file_obj.name))
     return gemini_api.count_input_tokens(
         character_name=character_name, api_key_name=api_key_name, parts=parts_for_api,
+        # ▼▼▼ 引数を追加 ▼▼▼
         api_history_limit=api_history_limit,
         add_timestamp=add_timestamp, send_thoughts=send_thoughts, send_notepad=send_notepad,
         use_common_prompt=use_common_prompt, send_core_memory=send_core_memory, send_scenery=send_scenery
@@ -154,7 +188,10 @@ def handle_message_submission(*args: Any):
 
     chatbot_history.append((None, "思考中... ▌"))
 
+    # ▼▼▼ この yield 文を修正 ▼▼▼
+    # 9個しか返していなかったタプルの最後に、10個目として gr.update() を追加します
     yield (chatbot_history, [], gr.update(value=""), gr.update(value=None), gr.update(), gr.update(), gr.update(), gr.update(), gr.update(), gr.update())
+    # ▲▲▲ 修正ここまで ▲▲▲
 
     response_data = {}
     try:
@@ -170,15 +207,17 @@ def handle_message_submission(*args: Any):
     final_response_text = response_data.get("response", "")
     location_name, scenery_text = response_data.get("location_name", "（取得失敗）"), response_data.get("scenery", "（取得失敗）")
 
+    # ▼▼▼ 修正の核心(B)：AIの応答から得た情景をキャッシュに保存 ▼▼▼
     scenery_image_path = None
     if not location_name.startswith("（"):
-        save_scenery_cache(current_character_name, location_name, scenery_text)
-        scenery_image_path = find_scenery_image(current_character_name)
+        utils.save_scenery_cache(current_character_name, location_name, scenery_text)
+        current_location_id = utils.get_current_location(current_character_name)
+        scenery_image_path = utils.find_scenery_image(current_character_name, current_location_id)
 
     log_f, _, _, _, _ = get_character_files_paths(current_character_name)
     final_log_message = "\n\n".join(log_message_parts).strip()
     if final_log_message:
-        user_header = _get_user_header_from_log(current_character_name)
+        user_header = utils._get_user_header_from_log(log_f, current_character_name)
         utils.save_message_to_log(log_f, user_header, final_log_message)
     if final_response_text:
         utils.save_message_to_log(log_f, f"## {current_character_name}:", final_response_text)
@@ -193,24 +232,28 @@ def handle_message_submission(*args: Any):
 
 def handle_scenery_refresh(character_name: str, api_key_name: str) -> Tuple[str, str, Optional[str]]:
     if not character_name or not api_key_name:
-        return "（キャラクターまたはAPIキーが未選択です）", "（エラー）", None
+        return "（キャラクターまたはAPIキーが未選択です）", "（キャラクターまたはAPIキーが未選択です）", None
+
+    api_key = config_manager.API_KEYS.get(api_key_name)
+    if not api_key:
+        gr.Warning(f"APIキー '{api_key_name}' が見つかりません。")
+        return "（APIキーエラー）", "（APIキーエラー）", None
 
     gr.Info(f"「{character_name}」の現在の情景を更新しています...")
 
-    internal_prompt = "（システムコマンド：現在の場所と情景を描写してください）"
-    agent_args = (internal_prompt, character_name, api_key_name, None, "1", False)
-    response_data = gemini_api.invoke_nexus_agent(*agent_args)
+    # ▼▼▼ 修正の核心: エージェント全体ではなく、軽量な専用関数を呼び出す ▼▼▼
+    location_name, _, scenery_text = generate_scenery_context(character_name, api_key)
+    # ▲▲▲ 修正ここまで ▲▲▲
 
-    location_name = response_data.get("location_name", "（取得失敗）")
-    scenery_text = response_data.get("scenery", "（取得失敗）")
-
-    scenery_image_path = None
     if not location_name.startswith("（"):
-        save_scenery_cache(character_name, location_name, scenery_text)
-        scenery_image_path = find_scenery_image(character_name)
+        utils.save_scenery_cache(character_name, location_name, scenery_text)
         gr.Info("情景を更新しました。")
+        current_location_id = utils.get_current_location(character_name)
+        # ▼▼▼ 修正箇所：探すだけ。なければNoneを返す。 ▼▼▼
+        scenery_image_path = utils.find_scenery_image(character_name, current_location_id)
     else:
         gr.Error("情景の更新に失敗しました。")
+        scenery_image_path = None
 
     return location_name, scenery_text, scenery_image_path
 
@@ -218,39 +261,48 @@ def handle_location_change(character_name: str, location_id: str) -> Tuple[str, 
     from tools.space_tools import set_current_location
     print(f"--- UIからの場所変更処理開始: キャラクター='{character_name}', 移動先ID='{location_id}' ---")
 
+    # --- エラー発生時のために、現在の状態を先に取得しておく ---
     current_loc_name = "（場所不明）"
     scenery_text = "（場所の変更に失敗しました）"
     current_image_path = None
-    cache = load_scenery_cache(character_name)
-    if cache:
-        current_loc_name = cache.get("location_name", current_loc_name)
-        scenery_text = cache.get("scenery_text", scenery_text)
+    scenery_cache = utils.load_scenery_cache(character_name)
+    if scenery_cache:
+        current_loc_name = scenery_cache.get("location_name", current_loc_name)
+        scenery_text = scenery_cache.get("scenery_text", scenery_text)
 
-    current_image_path = find_scenery_image(character_name)
+    # 現在の画像も取得しておく
+    current_location_id_before_move = utils.get_current_location(character_name)
+    current_image_path = utils.find_scenery_image(character_name, current_location_id_before_move)
 
     if not character_name or not location_id:
         gr.Warning("キャラクターと移動先の場所を選択してください。")
         return current_loc_name, scenery_text, current_image_path
 
+    # --- ツールを呼び出して現在地ファイルを更新 ---
     result = set_current_location.func(location=location_id, character_name=character_name)
 
     if "Success" not in result:
         gr.Error(f"場所の変更に失敗しました: {result}")
         return current_loc_name, scenery_text, current_image_path
 
+    # --- 成功した場合、UI表示の更新を行う ---
     gr.Info(f"場所を「{location_id}」に移動しました。")
 
+    # 新しい場所の名前を取得
     world_settings_path = get_world_settings_path(character_name)
-    world_data = utils.parse_world_markdown(world_settings_path)
-    new_location_name = location_id
+    from utils import parse_world_markdown
+    world_data = parse_world_markdown(world_settings_path)
+    new_location_name = location_id # デフォルト
     if world_data:
-        space_data = character_manager.find_space_data_by_id_recursive(world_data, location_id)
+        from character_manager import find_space_data_by_id_recursive
+        space_data = find_space_data_by_id_recursive(world_data, location_id)
         if space_data and isinstance(space_data, dict):
             new_location_name = space_data.get("name", location_id)
 
     new_scenery_text = f"（場所を「{new_location_name}」に移動しました。「情景を更新」ボタン、またはAIとの対話で新しい景色を確認できます）"
 
-    new_image_path = find_scenery_image(character_name)
+    # ▼▼▼ 修正の核心: 新しい場所の画像を探して返す ▼▼▼
+    new_image_path = utils.find_scenery_image(character_name, location_id)
 
     return new_location_name, new_scenery_text, new_image_path
 
@@ -275,7 +327,8 @@ def handle_chatbot_selection(character_name: str, api_history_limit_state: str, 
         if not (0 <= clicked_ui_index < len(mapping_list)):
             gr.Warning(f"クリックされたメッセージを特定できませんでした (UI index {clicked_ui_index} out of bounds for mapping list size {len(mapping_list)})."); return None, gr.update(visible=False)
 
-        raw_history = load_chat_log(character_name)
+        log_f, _, _, _, _ = get_character_files_paths(character_name)
+        raw_history = utils.load_chat_log(log_f, character_name)
         display_turns = _get_display_history_count(api_history_limit_state)
         visible_raw_history = raw_history[-(display_turns * 2):]
 
@@ -292,7 +345,8 @@ def handle_delete_button_click(message_to_delete: Optional[Dict[str, str]], char
     if not message_to_delete:
         return gr.update(), gr.update(), None, gr.update(visible=False)
 
-    if delete_message_from_log(character_name, message_to_delete):
+    log_f, _, _, _, _ = get_character_files_paths(character_name)
+    if utils.delete_message_from_log(log_f, message_to_delete, character_name):
         gr.Info("ログからメッセージを削除しました。")
     else:
         gr.Error("メッセージの削除に失敗しました。詳細はターミナルを確認してください。")
@@ -304,16 +358,28 @@ def reload_chat_log(character_name: Optional[str], api_history_limit_value: str)
     if not character_name:
         return [], []
 
-    full_raw_history = load_chat_log(character_name)
+    log_f,_,_,_,_ = get_character_files_paths(character_name)
+    if not log_f or not os.path.exists(log_f):
+        return [], []
 
+    # ▼▼▼ 修正の核心(2) ▼▼▼
+    # 1. まずログファイル全体を読み込む
+    full_raw_history = utils.load_chat_log(log_f, character_name)
+
+    # 2. 表示する件数を決定する
     display_turns = _get_display_history_count(api_history_limit_value)
 
+    # 3. 表示する件数分だけ、ログの末尾から切り出す (スライスする)
     visible_history = full_raw_history[-(display_turns * 2):]
 
+    # 4. 切り出した部分だけをUI変換にかけ、その中での座標を持つUI対応表を生成する
     history, mapping_list = utils.format_history_for_gradio(visible_history, character_name)
 
     return history, mapping_list
+    # ▲▲▲ 修正ここまで ▲▲▲
 
+# (以降の関数は変更なし)
+# ... (handle_save_memory_click から handle_voice_preview まで)
 def handle_save_memory_click(character_name, json_string_data):
     if not character_name: gr.Warning("キャラクターが選択されていません。"); return gr.update()
     try: return save_memory_data(character_name, json_string_data)
@@ -500,20 +566,22 @@ def handle_generate_or_regenerate_scenery_image(character_name: str, api_key_nam
         gr.Warning(f"APIキー '{api_key_name}' が見つかりません。")
         return None
 
-    location_id = get_current_location(character_name)
-    scenery_cache = load_scenery_cache(character_name)
+    location_id = utils.get_current_location(character_name)
+    scenery_cache = utils.load_scenery_cache(character_name)
     scenery_text = scenery_cache.get("scenery_text")
 
     if not location_id or not scenery_text:
         gr.Warning("生成の元となる場所の情報または情景描写が見つかりません。")
         return None
 
+    # ▼▼▼ 修正箇所：メッセージを汎用的にする ▼▼▼
     gr.Info(f"「{location_id}」の情景画像を生成/更新しています...")
 
+    # --- trigger_scenery_image_generation の中身を、スレッドなしで実行 ---
     prompt = f"A photorealistic, atmospheric, wide-angle landscape painting of the following scene. Do not include any people, characters, text, or watermarks. Style: cinematic, detailed, epic. Scene: {scenery_text}"
 
     now = datetime.datetime.now()
-    filename = f"{location_id}_{character_manager.get_season(now.month)}_{character_manager.get_time_of_day(now.hour)}.png"
+    filename = f"{location_id}_{utils.get_season(now.month)}_{utils.get_time_of_day(now.hour)}.png"
     save_dir = os.path.join(constants.CHARACTERS_DIR, character_name, "spaces", "images")
     final_save_path = os.path.join(save_dir, filename)
 
@@ -522,15 +590,16 @@ def handle_generate_or_regenerate_scenery_image(character_name: str, api_key_nam
     if "Generated Image:" in result:
         generated_path = result.replace("[Generated Image: ", "").replace("]", "").strip()
         if os.path.exists(generated_path):
+            # 既存のファイルを上書きするために、一度削除
             if os.path.exists(final_save_path):
                 os.remove(final_save_path)
             os.rename(generated_path, final_save_path)
             print(f"--- 情景画像を再生成し、保存しました: {final_save_path} ---")
-            gr.Info("画像を生成/更新しました。")
-            return final_save_path
+            gr.Info("画像を生成/更新しました。") # メッセージを調整
+            return final_save_path # 新しい画像のパスをUIに返す
         else:
             gr.Error("画像の生成には成功しましたが、一時ファイルの特定に失敗しました。")
             return None
     else:
-        gr.Error(f"画像の生成/更新に失敗しました。AIの応答: {result}")
+        gr.Error(f"画像の生成/更新に失敗しました。AIの応答: {result}") # メッセージを調整
         return None

--- a/utils.py
+++ b/utils.py
@@ -1,11 +1,15 @@
-# utils.py (最終確定版)
+# utils.py (完全最終版)
 
+import datetime
 import os
 import re
 import traceback
 import html
 from typing import List, Dict, Optional, Tuple, Union
 import gradio as gr
+import yaml
+import character_manager
+import constants
 import sys
 import psutil
 from pathlib import Path
@@ -13,8 +17,6 @@ import json
 import time
 import uuid
 from bs4 import BeautifulSoup
-import yaml
-import datetime
 
 _model_token_limits_cache: Dict[str, Dict[str, int]] = {}
 LOCK_FILE_PATH = Path.home() / ".nexus_ark.global.lock"
@@ -33,18 +35,37 @@ def acquire_lock() -> bool:
             print("\n" + "="*60)
             print("!!! エラー: Nexus Arkの別プロセスが既に実行中です。")
             print(f"    - 実行中のPID: {pid}")
+            print(f"    - パス: {lock_info.get('path', '不明')}")
+            print("    多重起動はできません。既存のプロセスを終了するか、")
+            print("    タスクマネージャーからプロセスを強制終了してください。")
             print("="*60 + "\n")
             return False
         else:
             print("\n" + "!"*60)
             print("警告: 古いロックファイルを検出しました。")
+            print(f"  - 記録されていたPID: {pid or '不明'} (このプロセスは現在実行されていません)")
+            print("  古いロックファイルを自動的に削除して、処理を続行します。")
+            print("!"*60 + "\n")
             LOCK_FILE_PATH.unlink()
             time.sleep(0.5)
             _create_lock_file()
             print("--- ロックを取得しました (自動クリーンアップ後) ---")
             return True
+    except (json.JSONDecodeError, IOError) as e:
+        print(f"警告: ロックファイル '{LOCK_FILE_PATH}' が破損しているようです。エラー: {e}")
+        print("破損したロックファイルを削除して、処理を続行します。")
+        try:
+            LOCK_FILE_PATH.unlink()
+            time.sleep(0.5)
+            _create_lock_file()
+            print("--- ロックを取得しました (破損ファイル削除後) ---")
+            return True
+        except Exception as delete_e:
+            print(f"!!! エラー: 破損したロックファイルの削除に失敗しました: {delete_e}")
+            return False
     except Exception as e:
         print(f"!!! エラー: ロック処理中に予期せぬ問題が発生しました: {e}")
+        traceback.print_exc()
         return False
 
 def _create_lock_file():
@@ -53,24 +74,69 @@ def _create_lock_file():
 
 def release_lock():
     try:
-        if LOCK_FILE_PATH.exists():
-            with open(LOCK_FILE_PATH, "r", encoding="utf-8") as f:
-                lock_info = json.load(f)
-            if lock_info.get('pid') == os.getpid():
-                LOCK_FILE_PATH.unlink()
-                print("\n--- グローバル・ロックを解放しました ---")
+        if not LOCK_FILE_PATH.exists():
+            return
+        with open(LOCK_FILE_PATH, "r", encoding="utf-8") as f:
+            lock_info = json.load(f)
+        if lock_info.get('pid') == os.getpid():
+            LOCK_FILE_PATH.unlink()
+            print("\n--- グローバル・ロックを解放しました ---")
+        else:
+            print(f"\n警告: 自分のものではないロックファイル (PID: {lock_info.get('pid')}) を解放しようとしましたが、スキップしました。")
     except Exception as e:
         print(f"\n警告: ロックファイルの解放中にエラーが発生しました: {e}")
+
+def load_chat_log(file_path: str, character_name: str) -> List[Dict[str, str]]:
+    messages: List[Dict[str, str]] = []
+    if not character_name or not file_path or not os.path.exists(file_path):
+        return messages
+
+    ai_header = f"## {character_name}:"
+    alarm_header = "## システム(アラーム):"
+
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            content = f.read()
+    except Exception as e:
+        print(f"エラー: ログファイル '{file_path}' 読込エラー: {e}")
+        return messages
+
+    log_parts = re.split(r'^(## .*?:)$', content, flags=re.MULTILINE)
+
+    header = None
+    for part in log_parts:
+        part = part.strip()
+        if not part:
+            continue
+
+        if part.startswith("## ") and part.endswith(":"):
+            header = part
+        elif header:
+            if header == ai_header:
+                role = 'model'
+            else:
+                role = 'user'
+            messages.append({"role": role, "content": part})
+            header = None
+    return messages
 
 def format_history_for_gradio(raw_history: List[Dict[str, str]], character_name: str) -> Tuple[List[Tuple[Union[str, Tuple, None], Union[str, Tuple, None]]], List[int]]:
     if not raw_history:
         return [], []
-    gradio_history, mapping_list = [], []
+
+    gradio_history = []
+    mapping_list = []
     image_tag_pattern = re.compile(r"\[Generated Image: (.*?)\]")
+
     intermediate_list = []
+    # ▼▼▼ 修正の核心 ▼▼▼
+    # enumerateは渡されたraw_history(既にスライスされている)に対するインデックス(0, 1, 2...)を返すため、
+    # original_indexは常に「表示されているログの中での」正しい座標になる。
     for i, msg in enumerate(raw_history):
+    # ▲▲▲ 修正ここまで ▲▲▲
         content = msg.get("content", "").strip()
         if not content: continue
+
         last_end = 0
         for match in image_tag_pattern.finditer(content):
             if match.start() > last_end:
@@ -89,58 +155,147 @@ def format_history_for_gradio(raw_history: List[Dict[str, str]], character_name:
     text_part_index = 0
     for item in intermediate_list:
         if not item["content"]: continue
+
         if item["type"] == "text":
             prev_anchor = text_parts_with_anchors[text_part_index - 1]["anchor_id"] if text_part_index > 0 else None
             next_anchor = text_parts_with_anchors[text_part_index + 1]["anchor_id"] if text_part_index < len(text_parts_with_anchors) - 1 else None
+
             html_content = _format_text_content_for_gradio(item["content"], item["anchor_id"], prev_anchor, next_anchor)
+
             if item["role"] == "user":
                 gradio_history.append((html_content, None))
             else:
                 gradio_history.append((None, html_content))
+
             mapping_list.append(item["original_index"])
             text_part_index += 1
+
         elif item["type"] == "image":
             filepath = item["content"]
-            gradio_history.append((None, (filepath, os.path.basename(filepath))))
+            filename = os.path.basename(filepath)
+            gradio_history.append((None, (filepath, filename)))
             mapping_list.append(item["original_index"])
+
     return gradio_history, mapping_list
 
 def _format_text_content_for_gradio(content: str, current_anchor_id: str, prev_anchor_id: Optional[str], next_anchor_id: Optional[str]) -> str:
     up_button = f"<a href='#{prev_anchor_id or current_anchor_id}' class='message-nav-link' title='前の発言へ' style='padding: 1px 6px; font-size: 1.2em; text-decoration: none; color: #AAA;'>▲</a>"
     down_button = f"<a href='#{next_anchor_id}' class='message-nav-link' title='次の発言へ' style='padding: 1px 6px; font-size: 1.2em; text-decoration: none; color: #AAA;'>▼</a>" if next_anchor_id else ""
     delete_icon = "<span title='この発言を削除するには、メッセージ本文をクリックして選択してください' style='padding: 1px 6px; font-size: 1.0em; color: #555; cursor: pointer;'>🗑️</span>"
+
     button_container = f"<div style='text-align: right; margin-top: 8px;'>{up_button} {down_button} <span style='margin: 0 4px;'></span> {delete_icon}</div>"
+
     thoughts_pattern = re.compile(r"【Thoughts】(.*?)【/Thoughts】", re.DOTALL | re.IGNORECASE)
     thought_match = thoughts_pattern.search(content)
+
     final_parts = [f"<span id='{current_anchor_id}'></span>"]
+
     if thought_match:
         thoughts_content = thought_match.group(1).strip()
         escaped_thoughts = html.escape(thoughts_content).replace('\n', '<br>')
         final_parts.append(f"<div class='thoughts'>{escaped_thoughts}</div>")
+
     main_text = thoughts_pattern.sub("", content).strip()
     escaped_text = html.escape(main_text).replace('\n', '<br>')
     final_parts.append(f"<div>{escaped_text}</div>")
+
     final_parts.append(button_container)
+
     return "".join(final_parts)
 
 def save_message_to_log(log_file_path: str, header: str, text_content: str) -> None:
-    if not all([log_file_path, header, text_content, text_content.strip()]): return
+    if not all([log_file_path, header, text_content, text_content.strip()]):
+        return
     try:
-        content_to_append = f"\n\n{header}\n{text_content.strip()}"
         if not os.path.exists(log_file_path) or os.path.getsize(log_file_path) == 0:
-            content_to_append = content_to_append.lstrip()
-        with open(log_file_path, "a", encoding="utf-8") as f: f.write(content_to_append)
+            content_to_append = f"{header}\n{text_content.strip()}"
+        else:
+            content_to_append = f"\n\n{header}\n{text_content.strip()}"
+
+        with open(log_file_path, "a", encoding="utf-8") as f:
+            f.write(content_to_append)
     except Exception as e:
         print(f"エラー: ログファイル '{log_file_path}' 書き込みエラー: {e}")
+        traceback.print_exc()
+
+def delete_message_from_log(log_file_path: str, message_to_delete: Dict[str, str], character_name: str) -> bool:
+    if not log_file_path or not os.path.exists(log_file_path) or not message_to_delete:
+        return False
+
+    try:
+        all_messages = load_chat_log(log_file_path, character_name)
+
+        try:
+            all_messages.remove(message_to_delete)
+        except ValueError:
+            print(f"警告: ログファイル内に削除対象のメッセージが見つかりませんでした。")
+            print(f"  - 検索対象: {message_to_delete}")
+            return False
+
+        log_content_parts = []
+        user_header = _get_user_header_from_log(log_file_path, character_name)
+        ai_header = f"## {character_name}:"
+
+        for msg in all_messages:
+            header = ai_header if msg['role'] == 'model' else user_header
+            content = msg['content'].strip()
+            log_content_parts.append(f"{header}\n{content}")
+
+        new_log_content = "\n\n".join(log_content_parts)
+        with open(log_file_path, "w", encoding="utf-8") as f:
+            f.write(new_log_content)
+
+        if new_log_content:
+            with open(log_file_path, "a", encoding="utf-8") as f:
+                f.write("\n\n")
+
+        print("--- Successfully deleted message from log ---")
+        return True
+    except Exception as e:
+        print(f"エラー: ログからのメッセージ削除中に予期せぬエラー: {e}")
+        traceback.print_exc()
+        return False
+
+def _get_user_header_from_log(log_file_path: str, ai_character_name: str) -> str:
+    default_user_header = "## ユーザー:"
+    if not log_file_path or not os.path.exists(log_file_path):
+        return default_user_header
+
+    last_identified_user_header = default_user_header
+    try:
+        with open(log_file_path, "r", encoding="utf-8") as f:
+            for line in f:
+                stripped_line = line.strip()
+                if stripped_line.startswith("## ") and stripped_line.endswith(":"):
+                    if not stripped_line.startswith(f"## {ai_character_name}:") and not stripped_line.startswith("## システム("):
+                        last_identified_user_header = stripped_line
+        return last_identified_user_header
+    except Exception as e:
+        print(f"エラー: ユーザーヘッダー取得エラー: {e}")
+        return default_user_header
 
 def remove_thoughts_from_text(text: str) -> str:
-    if not text: return ""
+    if not text:
+        return ""
     thoughts_pattern = re.compile(r"【Thoughts】.*?【/Thoughts】\s*", re.DOTALL | re.IGNORECASE)
     return thoughts_pattern.sub("", text).strip()
 
+def get_current_location(character_name: str) -> Optional[str]:
+    try:
+        location_file_path = os.path.join("characters", character_name, "current_location.txt")
+        if os.path.exists(location_file_path):
+            with open(location_file_path, 'r', encoding='utf-8') as f:
+                return f.read().strip()
+    except Exception as e:
+        print(f"警告: 現在地ファイルの読み込みに失敗しました: {e}")
+    return None
+
 def extract_raw_text_from_html(html_content: Union[str, tuple, None]) -> str:
-    if not html_content or not isinstance(html_content, str): return ""
+    if not html_content or not isinstance(html_content, str):
+        return ""
+
     soup = BeautifulSoup(html_content, 'html.parser')
+
     thoughts_text = ""
     thoughts_div = soup.find('div', class_='thoughts')
     if thoughts_div:
@@ -148,36 +303,143 @@ def extract_raw_text_from_html(html_content: Union[str, tuple, None]) -> str:
         thoughts_content = thoughts_div.get_text()
         if thoughts_content: thoughts_text = f"【Thoughts】\n{thoughts_content.strip()}\n【/Thoughts】\n\n"
         thoughts_div.decompose()
+
     for nav_div in soup.find_all('div', style=lambda v: v and 'text-align: right' in v): nav_div.decompose()
     for anchor_span in soup.find_all('span', id=lambda v: v and v.startswith('msg-anchor-')): anchor_span.decompose()
+
     for br in soup.find_all("br"): br.replace_with("\n")
     main_text = soup.get_text()
+
     return (thoughts_text + main_text).strip()
 
+
+# ▼▼▼ ここからが追加箇所（ファイルの一番下） ▼▼▼
+def load_scenery_cache(character_name: str) -> dict:
+    """指定されたキャラクターの情景キャッシュファイルを安全に読み込む。"""
+    if not character_name:
+        return {}
+    cache_path = os.path.join(constants.CHARACTERS_DIR, character_name, "last_scenery.json")
+    if os.path.exists(cache_path):
+        try:
+            with open(cache_path, "r", encoding="utf-8") as f:
+                content = f.read()
+                if not content.strip(): return {} # ファイルが空の場合の対策
+                data = json.loads(content)
+                return data if isinstance(data, dict) else {}
+        except (json.JSONDecodeError, IOError):
+            # ファイルが破損している、または読み取り中にエラーが発生した場合
+            return {}
+    return {}
+
+def save_scenery_cache(character_name: str, location_name: str, scenery_text: str):
+    """指定されたキャラクターの情景キャッシュファイルにデータを保存する。"""
+    if not character_name:
+        return
+    cache_path = os.path.join(constants.CHARACTERS_DIR, character_name, "last_scenery.json")
+    try:
+        data_to_save = {
+            "location_name": location_name,
+            "scenery_text": scenery_text,
+            "timestamp": datetime.datetime.now().isoformat()
+        }
+        with open(cache_path, "w", encoding="utf-8") as f:
+            json.dump(data_to_save, f, indent=2, ensure_ascii=False)
+    except Exception as e:
+        print(f"!! エラー: 情景キャッシュの保存に失敗しました: {e}")
+# ▲▲▲ 追加箇所ここまで ▲▲▲
+
+
+def get_season(month: int) -> str:
+    """月情報から季節を返す"""
+    if month in [3, 4, 5]: return "spring"
+    if month in [6, 7, 8]: return "summer"
+    if month in [9, 10, 11]: return "autumn"
+    return "winter"
+
+def get_time_of_day(hour: int) -> str:
+    """時間情報から時間帯を返す"""
+    if 5 <= hour < 10: return "morning"
+    if 10 <= hour < 17: return "daytime"
+    if 17 <= hour < 21: return "evening"
+    return "night"
+
+def find_scenery_image(character_name: str, location_id: str) -> Optional[str]:
+    """
+    指定された場所・季節・時間帯に最適な情景画像を、階層的に検索してパスを返す。
+    """
+    if not character_name or not location_id:
+        return None
+
+    image_dir = os.path.join(constants.CHARACTERS_DIR, character_name, "spaces", "images")
+    if not os.path.isdir(image_dir):
+        return None
+
+    now = datetime.datetime.now()
+    season = get_season(now.month)
+    time_of_day = get_time_of_day(now.hour)
+
+    potential_filenames = [
+        f"{location_id}_{season}_{time_of_day}.png",
+        f"{location_id}_{season}.png",
+        f"{location_id}.png"
+    ]
+
+    for filename in potential_filenames:
+        filepath = os.path.join(image_dir, filename)
+        if os.path.exists(filepath):
+            print(f"  - 情景画像を発見: {filepath}")
+            return filepath
+
+    print(f"  - 適切な情景画像が見つかりませんでした。")
+    return None
+
 def parse_world_markdown(file_path: str) -> dict:
-    if not os.path.exists(file_path): return {}
-    with open(file_path, "r", encoding="utf-8") as f: content = f.read()
+    """
+    世界設定が記述されたMarkdownファイルを解析し、ネストされた辞書構造に変換する。
+    見出し(##, ###)でセクションを分割し、各セクションをYAMLとして解析する堅牢な方式。
+    """
+    if not os.path.exists(file_path):
+        return {}
+
+    with open(file_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
     world_data = {}
+
+    # re.splitのキャプチャグループ `()` を使い、見出し(デリミタ)を保持したまま分割する
+    # 結果は ['(空)', '## area1', 'area1の中身', '## area2', 'area2の中身', ...] というリストになる
     sections = re.split(r'(^## .*)', content, flags=re.MULTILINE)
+
+    # 最初の要素はヘッダー部分なので無視し、2つずつペアで処理する
     for i in range(1, len(sections), 2):
         area_key = sections[i][3:].strip()
         area_content = sections[i+1]
+
         world_data[area_key] = {}
+
+        # ### でさらに部屋ごとに分割
         sub_sections = re.split(r'(^### .*)', area_content, flags=re.MULTILINE)
+
+        # ### の前にあるエリア直下のプロパティを解析
         area_props_content = sub_sections[0].strip()
         if area_props_content:
             try:
                 area_props = yaml.safe_load(area_props_content)
-                if isinstance(area_props, dict): world_data[area_key].update(area_props)
+                if isinstance(area_props, dict):
+                    world_data[area_key].update(area_props)
             except yaml.YAMLError as e:
                 print(f"警告: エリア '{area_key}' のプロパティ解析中にエラー: {e}")
+
+        # 各部屋のセクションを解析
         for j in range(1, len(sub_sections), 2):
             room_key = sub_sections[j][4:].strip()
             room_content = sub_sections[j+1].strip()
             if room_content:
                 try:
                     room_props = yaml.safe_load(room_content)
-                    if isinstance(room_props, dict): world_data[area_key][room_key] = room_props
+                    if isinstance(room_props, dict):
+                        world_data[area_key][room_key] = room_props
                 except yaml.YAMLError as e:
                     print(f"警告: 部屋 '{room_key}' の解析中にエラー: {e}")
+
     return world_data


### PR DESCRIPTION
This commit resolves a critical startup error for new users by making the configuration loading process in `config_manager.py` more robust.

Previously, the application would crash if the `last_api_key_name` stored in `config.json` was not present in the list of `api_keys`. This commonly occurred during a fresh installation where you would correctly add your key to the `api_keys` dictionary but would not know to update the `last_api_key_name` field.

The `load_config` function has been rewritten to:
1.  Load the list of available API key names.
2.  Validate the `last_api_key_name` from the config against this valid list.
3.  If the last key is invalid or not found, it attempts to fall back to the `default_api_key_name`.
4.  If both are invalid, it safely falls back to using the first available key from the `api_keys` list.
5.  If no valid keys are configured, it gracefully handles the situation without crashing.

This ensures a smooth first-time experience for you and makes the application more resilient to inconsistencies in the configuration file.