### PR TITLE
refactor: Remove noisy debug print from token counting function

### DIFF
--- a/gemini_api.py
+++ b/gemini_api.py
@@ -203,7 +203,6 @@ def count_input_tokens(**kwargs):
 
         # 履歴制限を適用する
         if limit > 0 and len(raw_history) > limit * 2:
-            print(f"  - [Token Count] 履歴を последние {limit} ターンに制限します。")
             raw_history = raw_history[-(limit * 2):]
         # ▲▲▲ 修正ここまで ▲▲▲
 


### PR DESCRIPTION
This commit removes a leftover debug `print` statement from the `count_input_tokens` function in `gemini_api.py`.

This print statement was generating a significant amount of noise in the terminal during normal application use (e.g., on every key press in the input box), making it difficult to see important log messages.

As the feature it was debugging is confirmed to be working correctly, this log is no longer needed.