### PR TITLE
feat: 「再生成」ボタンの機能を拡張

### DIFF
--- a/nexus_ark.py
+++ b/nexus_ark.py
@@ -285,7 +285,12 @@ try:
         )
 
         chat_reload_button.click(fn=ui_handlers.reload_chat_log, inputs=[current_character_name, api_history_limit_state], outputs=[chatbot_display, current_log_map_state])
-        chatbot_display.select(fn=ui_handlers.handle_chatbot_selection, inputs=[current_character_name, api_history_limit_state, current_log_map_state], outputs=[selected_message_state, action_button_group], show_progress=False)
+        chatbot_display.select(
+            fn=ui_handlers.handle_chatbot_selection,
+            inputs=[current_character_name, api_history_limit_state, current_log_map_state],
+            outputs=[selected_message_state, action_button_group, play_audio_button], # play_audio_button を追加
+            show_progress=False
+        )
 
         rerun_button.click(
             fn=ui_handlers.handle_rerun_button_click,

--- a/utils.py
+++ b/utils.py
@@ -708,3 +708,58 @@ def capture_prints():
     finally:
         sys.stdout = original_stdout
         sys.stderr = original_stderr
+
+def delete_user_message_and_after(log_file_path: str, user_message_to_delete: Dict[str, str], character_name: str) -> Optional[str]:
+    """
+    指定されたユーザーのメッセージと、それ以降の全てのAIメッセージをログから削除し、
+    そのユーザーメッセージの内容を返す。
+    """
+    if not all([log_file_path, os.path.exists(log_file_path), user_message_to_delete, character_name]):
+        return None
+
+    try:
+        all_messages = load_chat_log(log_file_path, character_name)
+
+        # 削除対象のユーザーメッセージのインデックスを探す
+        target_index = -1
+        for i, msg in enumerate(all_messages):
+            if (msg.get("content") == user_message_to_delete.get("content") and
+                msg.get("responder") == user_message_to_delete.get("responder")):
+                target_index = i
+                break
+
+        if target_index == -1:
+            print(f"警告: ログファイル内に削除対象のユーザーメッセージが見つかりませんでした。")
+            return None
+
+        # ユーザーの発言内容を保持し、それ以降のメッセージを全て削除対象とする
+        user_message_content = all_messages[target_index].get("content", "")
+        messages_to_keep = all_messages[:target_index]
+
+        # ログを再構築する
+        log_content_parts = []
+        for msg in messages_to_keep:
+            responder_name = msg.get("responder", "不明")
+            header = f"## {responder_name}:"
+            content = msg.get('content', '').strip()
+            if content:
+                log_content_parts.append(f"{header}\n{content}")
+
+        new_log_content = "\n\n".join(log_content_parts)
+        with open(log_file_path, "w", encoding="utf-8") as f:
+            f.write(new_log_content)
+        if new_log_content:
+            with open(log_file_path, "a", encoding="utf-8") as f:
+                f.write("\n\n")
+
+        # タイムスタンプを除去したユーザーの発言内容を返す
+        content_without_timestamp = re.sub(r'\n\n\d{4}-\d{2}-\d{2} \(...\) \d{2}:\d{2}:\d{2}$', '', user_message_content, flags=re.MULTILINE)
+        restored_input = content_without_timestamp.strip()
+
+        print("--- Successfully reset conversation to the selected user input for rerun ---")
+        return restored_input
+
+    except Exception as e:
+        print(f"エラー: ユーザー発言以降のログ削除中に予期せぬエラー: {e}")
+        traceback.print_exc()
+        return None


### PR DESCRIPTION
あなたの発言を選択した場合にも「再生成」ボタンが機能するように修正しました。

- あなたの発言を選択した場合、その発言以降の私の応答をすべて削除し、そこから応答を再生成します。
- 私の発言を選択した場合は、これまで通りその発言と直前のあなたの発言を削除して再生成します。
- UIを調整し、あなたの発言を選択した際には音声再生ボタンを非活性化するようにしました。