### PR TITLE
Refactor: Remove individual AI model setting from room configuration

### DIFF
--- a/gemini_api.py
+++ b/gemini_api.py
@@ -119,12 +119,10 @@ def invoke_nexus_agent_stream(agent_args: dict) -> Iterator[Dict[str, Any]]:
 
     all_participants_list = [soul_vessel_room] + active_participants
     global_model_from_ui = agent_args.get("global_model_from_ui")
-    room_model_from_ui = agent_args.get("room_model_from_ui")
 
     effective_settings = config_manager.get_effective_settings(
         room_to_respond,
         global_model_from_ui=global_model_from_ui,
-        room_model_from_ui=room_model_from_ui,
         use_common_prompt=(len(all_participants_list) <= 1)
     )
     model_name = effective_settings["model_name"]

--- a/nexus_ark.py
+++ b/nexus_ark.py
@@ -198,7 +198,6 @@ try:
                                         gr.Warning("APIキーやWebhook URLはPC上の `config.json` ファイルに平文で保存されます。取り扱いには十分ご注意ください。")
                                 with gr.TabItem("個別設定"):
                                     room_settings_info = gr.Markdown("ℹ️ *現在選択中のルーム「...」にのみ適用される設定です。*")
-                                    room_model_dropdown = gr.Dropdown(label="使用するAIモデル（個別）", interactive=True)
                                     with gr.Accordion("🎤 音声設定", open=False):
                                         room_voice_dropdown = gr.Dropdown(label="声を選択（個別）", choices=list(config_manager.SUPPORTED_VOICES.values()), interactive=True)
                                         room_voice_style_prompt_textbox = gr.Textbox(label="音声スタイルプロンプト", placeholder="例：囁くように、楽しそうに、落ち着いたトーンで", interactive=True)
@@ -449,7 +448,7 @@ try:
             profile_image_display,
             memory_json_editor, notepad_editor, system_prompt_editor,
             alarm_room_dropdown, timer_room_dropdown, manage_room_selector, location_dropdown,
-            current_location_display, current_scenery_display, room_model_dropdown, room_voice_dropdown,
+            current_location_display, current_scenery_display, room_voice_dropdown,
             room_voice_style_prompt_textbox,
             room_temperature_slider, room_top_p_slider,
             room_safety_harassment_dropdown, room_safety_hate_speech_dropdown,
@@ -495,7 +494,6 @@ try:
             auto_memory_checkbox,
             debug_console_state,
             active_participants_state,
-            room_model_dropdown,
             model_dropdown
         ]
 
@@ -507,7 +505,6 @@ try:
                 # auto_memory_checkbox を削除
                 debug_console_state,
                 active_participants_state,
-                room_model_dropdown,
                 model_dropdown
             ],
             outputs=[
@@ -624,7 +621,7 @@ try:
         ]
         save_room_settings_button.click(
             fn=ui_handlers.handle_save_room_settings,
-            inputs=[current_room_name, room_model_dropdown, room_voice_dropdown, room_voice_style_prompt_textbox] + gen_settings_inputs + context_checkboxes + [auto_memory_checkbox],
+            inputs=[current_room_name, room_voice_dropdown, room_voice_style_prompt_textbox] + gen_settings_inputs + context_checkboxes + [auto_memory_checkbox],
             outputs=None
         )
         room_preview_voice_button.click(fn=ui_handlers.handle_voice_preview, inputs=[room_voice_dropdown, room_voice_style_prompt_textbox, room_preview_text_textbox, api_key_dropdown], outputs=[audio_player, play_audio_button, room_preview_voice_button])

--- a/ui_handlers.py
+++ b/ui_handlers.py
@@ -72,7 +72,7 @@ def _create_redaction_df_from_rules(rules: List[Dict]) -> pd.DataFrame:
 def _update_chat_tab_for_room_change(room_name: str, api_key_name: str):
     """
     【修正】チャットタブと、それに付随する設定UIの更新のみを担当するヘルパー関数。
-    戻り値の数は `initial_load_chat_outputs` の31個と一致する。
+    戻り値の数は `initial_load_chat_outputs` の30個と一致する。
     """
     if not room_name:
         room_list = room_manager.get_room_list_for_ui()
@@ -94,8 +94,6 @@ def _update_chat_tab_for_room_change(room_name: str, api_key_name: str):
     current_location_name, _, scenery_text = generate_scenery_context(room_name, api_key)
     scenery_image_path = utils.find_scenery_image(room_name, location_dd_val)
     effective_settings = config_manager.get_effective_settings(room_name)
-    all_models = ["デフォルト"] + config_manager.AVAILABLE_MODELS_GLOBAL
-    model_val = effective_settings["model_name"] if effective_settings["model_name"] != config_manager.initial_model_global else "デフォルト"
     voice_display_name = config_manager.SUPPORTED_VOICES.get(effective_settings.get("voice_id", "iapetus"), list(config_manager.SUPPORTED_VOICES.values())[0])
     voice_style_prompt_val = effective_settings.get("voice_style_prompt", "")
     safety_display_map = {
@@ -109,7 +107,7 @@ def _update_chat_tab_for_room_change(room_name: str, api_key_name: str):
     sexual_val = safety_display_map.get(effective_settings.get("safety_block_threshold_sexually_explicit"))
     dangerous_val = safety_display_map.get(effective_settings.get("safety_block_threshold_dangerous_content"))
 
-    # このタプルの要素数は31個
+    # このタプルの要素数は30個
     chat_tab_updates = (
         room_name, chat_history, mapping_list,
         gr.update(value={'text': '', 'files': []}), # 2つの戻り値を、MultimodalTextbox用の1つの辞書に統合
@@ -120,7 +118,7 @@ def _update_chat_tab_for_room_change(room_name: str, api_key_name: str):
         gr.update(choices=room_manager.get_room_list_for_ui(), value=room_name),
         gr.update(choices=locations_for_ui, value=location_dd_val),
         current_location_name, scenery_text,
-        gr.update(choices=all_models, value=model_val), voice_display_name, voice_style_prompt_val,
+        voice_display_name, voice_style_prompt_val,
         temp_val, top_p_val, harassment_val, hate_val, sexual_val, dangerous_val,
         effective_settings["add_timestamp"], effective_settings["send_thoughts"],
         effective_settings["send_notepad"], effective_settings["use_common_prompt"],
@@ -172,7 +170,7 @@ def handle_initial_load(initial_room_to_load: str, initial_api_key_name: str):
     return (display_df, df_with_ids, feedback_text) + chat_tab_updates + (rules_df_for_ui,)
 
 def handle_save_room_settings(
-    room_name: str, model_name: str, voice_name: str, voice_style_prompt: str,
+    room_name: str, voice_name: str, voice_style_prompt: str,
     temp: float, top_p: float, harassment: str, hate: str, sexual: str, dangerous: str,
     add_timestamp: bool, send_thoughts: bool, send_notepad: bool,
     use_common_prompt: bool, send_core_memory: bool, send_scenery: bool,
@@ -188,7 +186,6 @@ def handle_save_room_settings(
     }
 
     new_settings = {
-        "model_name": model_name if model_name != "デフォルト" else None,
         "voice_id": next((k for k, v in config_manager.SUPPORTED_VOICES.items() if v == voice_name), None),
         "voice_style_prompt": voice_style_prompt.strip(),
         "temperature": temp,
@@ -289,7 +286,7 @@ def handle_message_submission(*args: Any):
     (multimodal_input, soul_vessel_room, current_api_key_name_state,
      api_history_limit_state, debug_mode_state,
      auto_memory_enabled, current_console_content, active_participants,
-     room_model, global_model) = args
+     global_model) = args
 
     textbox_content = multimodal_input.get("text", "") if multimodal_input else ""
     file_input_list = multimodal_input.get("files", []) if multimodal_input else []
@@ -361,7 +358,7 @@ def handle_message_submission(*args: Any):
 
             agent_args_dict = {
                 "room_to_respond": room_to_respond, "api_key_name": current_api_key_name_state,
-                "global_model_from_ui": global_model, "room_model_from_ui": room_model,
+                "global_model_from_ui": global_model,
                 "api_history_limit": api_history_limit_state, "debug_mode": debug_mode_state,
                 "history_log_path": main_log_f, "user_prompt_parts": user_prompt_parts,
                 "soul_vessel_room": soul_vessel_room, "active_participants": active_participants,
@@ -2050,7 +2047,7 @@ def handle_rerun_button_click(*args: Any):
     (selected_message, room_name, api_key_name,
      api_history_limit, debug_mode,
      current_console_content, active_participants,
-     room_model, global_model) = args
+     global_model) = args
 
     try:
         active_participants = active_participants or []
@@ -2110,7 +2107,6 @@ def handle_rerun_button_click(*args: Any):
             "room_to_respond": room_name,
             "api_key_name": api_key_name,
             "global_model_from_ui": global_model,
-            "room_model_from_ui": room_model,
             "api_history_limit": api_history_limit,
             "debug_mode": debug_mode,
             "history_log_path": log_f,


### PR DESCRIPTION
Removes the per-room AI model setting from the 'Individual Settings' tab. This feature was causing bugs where the setting would not save correctly and created confusion for users due to the presence of a separate 'Common Settings' model configuration.

This change simplifies the application by centralizing the AI model configuration into the 'Common Settings' tab only. The modifications include:
- Removing the 'AI Model (Individual)' dropdown from the UI.
- Deleting the backend logic for saving and loading this per-room setting.
- Updating all related function calls and configuration management logic to remove dependencies on the per-room model setting.