### PR TITLE
Refactor: Centralize search model name in constants

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -26,3 +26,7 @@ DEFAULT_ALARM_API_HISTORY_TURNS = 10
 # 情景生成や記憶の要約など、アプリケーション内部の高速処理タスクで使用するモデル。
 # これを一元管理することで、将来のモデル変更が容易になり、意図しない変更を防ぐ。
 INTERNAL_PROCESSING_MODEL = "gemini-2.5-flash-lite"
+
+# --- ツール専用AIモデル ---
+# 検索グラウンディングのように、特定の機能が保証されているモデルを必要とするツールで使用する。
+SEARCH_MODEL = "gemini-2.5-flash"

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -35,9 +35,9 @@ def web_search_tool(query: str, room_name: str) -> str:
             tools=[search_tool_for_api]
         )
 
-        # 3. 検索機能を持つ 'gemini-2.5-flash' を使用
+        # 3. 検索機能が保証された専用モデルを定数から呼び出す
         response = client.models.generate_content(
-            model='models/gemini-2.5-flash',
+            model=f'models/{constants.SEARCH_MODEL}', # ← この行を変更
             contents=[query],
             config=generation_config_with_tool
         )


### PR DESCRIPTION
Replaces the hard-coded model name 'gemini-2.5-flash' in `tools/web_tools.py` with a new constant, `SEARCH_MODEL`, defined in `constants.py`.

This refactoring improves maintainability by centralizing the model configuration, making future updates easier and safer.