### PR TITLE
fix(agent): Initialize loop_count to prevent infinite loop

### DIFF
--- a/gemini_api.py
+++ b/gemini_api.py
@@ -230,7 +230,8 @@ def invoke_nexus_agent_stream(agent_args: dict) -> Iterator[Dict[str, Any]]:
         "debug_mode": debug_mode,
         "location_name": shared_location_name,
         "scenery_text": shared_scenery_text,
-        "all_participants": all_participants_list
+        "all_participants": all_participants_list,
+        "loop_count": 0 # ← この行を追加
     }
 
     # [Julesによる修正] UI側で新規メッセージを特定できるように、最初のメッセージ数をカスタムイベントとして送信


### PR DESCRIPTION
The AI agent's re-thinking loop was entering an infinite loop because the `loop_count` state variable was not being initialized in the `invoke_nexus_agent_stream` function.

This caused the loop's termination condition (`loop_count < 2`) to never be met, as the counter was reset on every iteration.

This change initializes `loop_count` to 0 in the `initial_state` dictionary, ensuring the loop terminates correctly after two iterations.